### PR TITLE
Fixes to make protocol announce work

### DIFF
--- a/src/main/java/io/reticulum/Reticulum.java
+++ b/src/main/java/io/reticulum/Reticulum.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -40,6 +41,7 @@ import static io.reticulum.utils.CommonUtils.exit;
 import static io.reticulum.utils.CommonUtils.panic;
 import static io.reticulum.utils.IdentityUtils.fullHash;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
@@ -140,6 +142,10 @@ public class Reticulum implements ExitHandler {
         Signal.handle(new Signal("TERM"), sig -> sigtermHandler());
     }
 
+    public Reticulum getInstance() {
+        return this;
+    }
+
     /**
      * This exit handler is called whenever Reticulum is asked to
      * shut down, and will in turn call exit handlers in other
@@ -214,7 +220,14 @@ public class Reticulum implements ExitHandler {
                         ifacOrigin = ArrayUtils.addAll(ifacOrigin, fullHash(iface.getIfacNetKey().getBytes(UTF_8)));
                     }
 
+                    if (Objects.equals(iface.getType(), new String("TCPClientInterface"))) {
+                        if (isNull(iface.getIfacSize())) {
+                            iface.setIfacSize(16);
+                        }
+                    }
+
                     // TODO: 07.03.2023 проверить чтоб были хеши и ключи одинаковые с питоном
+                    //                  check that the hashes and keys are the same with Python
                     var ifacOriginHash = fullHash(ifacOrigin);
                     var hkdf = new HKDFBytesGenerator(new SHA256Digest());
                     hkdf.init(new HKDFParameters(ifacOriginHash, IFAC_SALT, new byte[0]));

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -1560,7 +1560,7 @@ public final class Transport implements ExitHandler {
         jobsLock.unlock();
     }
 
-    // TODO: 12.05.2023 подлежит рефакторингу.
+    // TODO: 12.05.2023 подлежит рефакторингу. (subject to refactoring)
     public boolean outbound(@NonNull final Packet packet) {
         while (isFalse(jobsLock.tryLock())) {
             //sleep
@@ -2050,6 +2050,10 @@ public final class Transport implements ExitHandler {
 
     public void registerAnnounceHandler(AnnounceHandler announceHandler) {
         announceHandlers.add(announceHandler);
+    }
+
+    public List<AnnounceHandler> getAnnounceHandlers() {
+        return announceHandlers;
     }
 
     public void deregisterAnnounceHandler(AnnounceHandler announceHandler) {

--- a/src/main/java/io/reticulum/destination/Destination.java
+++ b/src/main/java/io/reticulum/destination/Destination.java
@@ -379,6 +379,10 @@ public class Destination extends AbstractDestination {
             throw new IllegalStateException("Only SINGLE destination types can be announced");
         }
 
+        if (this.getDirection() != IN) {
+            throw new IllegalStateException("Only IN destination types can be announced");
+        }
+
         var staleResponses = new ArrayList<String>();
         var now = Instant.now();
         pathResponses.forEach((entryTag, entry) -> {

--- a/src/main/java/io/reticulum/identity/IdentityKnownDestination.java
+++ b/src/main/java/io/reticulum/identity/IdentityKnownDestination.java
@@ -1,5 +1,6 @@
 package io.reticulum.identity;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +17,7 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
 import org.msgpack.jackson.dataformat.MessagePackMapper;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -70,7 +72,7 @@ public class IdentityKnownDestination {
                 storage.forEach(KNOWN_DESTINATIONS::putIfAbsent);
                 Files.delete(destinationFilePath);
             }
-            log.debug("Saving {} known destinations to storage...", KNOWN_DESTINATIONS.keySet().size());
+            log.debug("saving known destinations to storage... {}", KNOWN_DESTINATIONS.keySet().size());
             OBJECT_MAPPER.writeValue(destinationFilePath.toFile(), KNOWN_DESTINATIONS);
             log.debug("Saved known destinations to storage in {} ms.", System.currentTimeMillis() - start);
         } catch (IOException e) {
@@ -241,9 +243,36 @@ public class IdentityKnownDestination {
     @NoArgsConstructor
     static final class DestinationData {
         private long timestamp;
-        private byte[] packetHash;
-        private byte[] publicKey;
-        private byte[] appData;
+        @JsonAlias({"packetHash"})
+        private byte[] packet_hash;
+        //private byte[] packetHash;
+        @JsonAlias({"publicKey"})
+        private byte[] public_key;
+        //private byte[] publicKey;
+        @JsonAlias({"appData"})
+        private byte[] app_data;
+        //private byte[] appData;
+
+        // getter
+        public byte[] getPackageHash() {
+            return packet_hash;
+        }
+        public byte[] getPublicKey() {
+            return public_key;
+        }
+        public byte[] getAppData() {
+            return app_data;
+        }
+        // setter
+        public void setPacketHash(byte[] packetHash) {
+            app_data = packetHash;
+        }
+        public void setPublicKey(byte[] publicKey) {
+            public_key = publicKey;
+        }
+        public void setAppData(byte[] appData) {
+            app_data = appData;
+        }
     }
 
     static int length(String key) {

--- a/src/main/java/io/reticulum/interfaces/AbstractConnectionInterface.java
+++ b/src/main/java/io/reticulum/interfaces/AbstractConnectionInterface.java
@@ -86,9 +86,7 @@ public abstract class AbstractConnectionInterface extends Thread implements Conn
     protected Queue<AnnounceQueueEntry> announceQueue = new LinkedList<>();
 
     public void setIfacSize(int newIfacSize) {
-        if (newIfacSize >= IFAC_MIN_SIZE * 8) {
-            ifacSize = newIfacSize / 8;
-        }
+        ifacSize = newIfacSize;
     }
 
     public void setIfacNetName(String newIfacNetname) {

--- a/src/main/java/io/reticulum/interfaces/tcp/PacketInboundHandler.java
+++ b/src/main/java/io/reticulum/interfaces/tcp/PacketInboundHandler.java
@@ -14,6 +14,7 @@ public class PacketInboundHandler extends SimpleChannelInboundHandler<byte[]> {
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, byte[] msg) throws Exception {
+        //log.trace("channelRead0. context: {}, interface: {}, message: {}", ctx.name(), connectionInterface.getInterfaceName() , msg);
         connectionInterface.processIncoming(msg);
     }
 
@@ -21,5 +22,11 @@ public class PacketInboundHandler extends SimpleChannelInboundHandler<byte[]> {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         log.error("Error while handle inbound packet in interface {}", connectionInterface, cause);
         ctx.close();
+    }
+
+    // implement abstract method (netty >= 4.x, channelRead renamed to messageReceived in netty 5)
+    public void messageReceived(ChannelHandlerContext ctx, Object msg) {
+        //log.trace("message received. context: {}, interface: {}, message: {}", ctx.name(), connectionInterface.getInterfaceName() , msg);
+        connectionInterface.processIncoming((byte[]) msg);
     }
 }

--- a/src/main/java/io/reticulum/interfaces/tcp/TCPClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/tcp/TCPClientInterface.java
@@ -157,7 +157,7 @@ public class TCPClientInterface extends AbstractConnectionInterface implements H
                             .accumulateAndGet(BigInteger.valueOf(data.length), BigInteger::add);
                 }
             } catch (Exception e) {
-                log.error("Exception occurred while transmitting via {}, tearing down interfac.", this, e);
+                log.error("Exception occurred while transmitting via {}, tearing down interface.", this, e);
             }
         }
     }

--- a/src/main/java/io/reticulum/packet/Packet.java
+++ b/src/main/java/io/reticulum/packet/Packet.java
@@ -28,6 +28,7 @@ import static io.reticulum.constant.ReticulumConstant.TRUNCATED_HASHLENGTH;
 import static io.reticulum.destination.DestinationType.LINK;
 import static io.reticulum.packet.HeaderType.HEADER_1;
 import static io.reticulum.packet.HeaderType.HEADER_2;
+import static io.reticulum.packet.PacketContextType.NONE;
 import static io.reticulum.packet.PacketContextType.CACHE_REQUEST;
 import static io.reticulum.packet.PacketContextType.KEEPALIVE;
 import static io.reticulum.packet.PacketContextType.LRPROOF;
@@ -203,14 +204,14 @@ public class Packet implements TPacket {
 
     private byte[] mapHash;
 
-    //дефолтные значения
+    //дефолтные значения (default values)
     private TransportType transportType = TransportType.BROADCAST;
     private HeaderType headerType = HEADER_1;
     private PacketType packetType = DATA;
-    private boolean createReceipt = true;
-    private PacketContextType context = null;
+    private PacketContextType context = NONE;
     private byte[] transportId = null;
     private ConnectionInterface attachedInterface = null;
+    private boolean createReceipt = true;
 
     private Packet(
             AbstractDestination destination,


### PR DESCRIPTION
Fixes to get the Java implementation of TCPClientInterface talking to the reference (Python) implementation of TCPServerInterface.  Fixes include::

- set default for ifacSize
- implement netty SimpleChannelInboundHandler method *messageReceived* for netty >=4.x
- other minor fixes

The test case is an Announce.java example. Verified result: 

- The Announced destination is correctly received by the TCPServerInterface and korrectly added to the known desinations on the "server" side.
- The Announced destination is re-broadcasted, received on the TCPClientInterface and korrectly added to know destinations on the "client" side.