### PR TITLE
fix method call args, provide context default for Packet

### DIFF
--- a/src/main/java/io/reticulum/identity/Identity.java
+++ b/src/main/java/io/reticulum/identity/Identity.java
@@ -126,8 +126,8 @@ public class Identity {
             pubBytes = subarray(publicKey, 0, KEYSIZE / 8 / 2);
             sigPubBytes = subarray(publicKey, KEYSIZE / 8 / 2, publicKey.length);
 
-            pub = new X25519PublicKeyParameters(pubBytes);
-            sigPub = new Ed25519PublicKeyParameters(sigPubBytes);
+            pub = new X25519PublicKeyParameters(pubBytes, 0);
+            sigPub = new Ed25519PublicKeyParameters(sigPubBytes, 0);
 
             updateHashes();
 

--- a/src/main/java/io/reticulum/packet/Packet.java
+++ b/src/main/java/io/reticulum/packet/Packet.java
@@ -42,6 +42,7 @@ import static io.reticulum.utils.IdentityUtils.concatArrays;
 import static io.reticulum.utils.IdentityUtils.fullHash;
 import static io.reticulum.utils.IdentityUtils.truncatedHash;
 import static java.math.BigInteger.ONE;
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.ArrayUtils.subarray;
@@ -369,6 +370,12 @@ public class Packet implements TPacket {
                     }
                     break;
             }
+        }
+        
+        // In Python the context defaults to NONE in the constructor
+        if (isNull(context)) {
+            context = NONE;
+            this.context = NONE;
         }
 
         packetData.setHeader(header);


### PR DESCRIPTION
Changes:

* fix: add additional parameter for X25519PublicKeyParameters and Ed25519PublicKeyParameters
* provide a default for Packet context (Python does this in the constructor). Without this a null pointer exception is thrown in the Packet classes.