### PR TITLE
add accessor outside of lombok Getter scope

### DIFF
--- a/src/main/java/io/reticulum/link/Link.java
+++ b/src/main/java/io/reticulum/link/Link.java
@@ -234,6 +234,10 @@ public class Link extends AbstractDestination {
 //            self.peer_pub.curve = Link.CURVE
     }
 
+    public boolean isInitiator() {
+        return this.initiator;
+    }
+
     public void setLinkId(Packet packet) {
         this.linkId = packet.getTruncatedHash();
         this.hash = this.linkId;


### PR DESCRIPTION
Added accessor "isInitiator" used in Transport. The generic lombok getter for attribute initiator is "getInitiator".