### PR TITLE
public transport methods hasPath and requestPath

### DIFF
--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -2413,6 +2413,28 @@ public final class Transport implements ExitHandler {
     }
 
     /**
+     * Check if the path to a destination exists.
+     * Note: if not, a call to requestPath(desitinationHash) may be able to retrieve it from the network.
+     * 
+     * @param destinationHash
+     */
+    public Boolean hasPath(@NonNull byte[] destinationPath) {
+        if (isNull(recall(destinationPath))) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Public version of the method requestPath.
+     * 
+     * @param destinationHash
+     */
+    public void requestPath(@NonNull byte[] destinationHash) {
+        requestPath(destinationHash, null, null, false);
+    }
+
+    /**
      * Requests a path to the destination from the network. If
      * another reachable peer on the network knows a path, it
      * will announce it.

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -2418,8 +2418,8 @@ public final class Transport implements ExitHandler {
      * 
      * @param destinationHash
      */
-    public Boolean hasPath(@NonNull byte[] destinationPath) {
-        if (isNull(recall(destinationPath))) {
+    public Boolean hasPath(@NonNull byte[] destinationHash) {
+        if (isNull(recall(destinationHash))) {
             return false;
         }
         return true;


### PR DESCRIPTION
Add two public methods of which the equivalents in Python are used in the Python "echo" example:

1. hasPath: corresponds to Python has_path
2. requestPath: public variant of existing private requestPath method taking only the destinationHash as argument.