### PR TITLE
Major Buffer read and Link Fixes

### DIFF
--- a/src/main/java/io/reticulum/buffer/RawChannelReader.java
+++ b/src/main/java/io/reticulum/buffer/RawChannelReader.java
@@ -116,7 +116,10 @@ public class RawChannelReader extends InputStream {
     public byte[] read(Integer readyBytes) throws IOException {
         lock.lock();
         try {
-            return Arrays.copyOfRange(buffer, 0, readyBytes);
+            //return Arrays.copyOfRange(buffer, 0, readyBytes);
+            var result = Arrays.copyOfRange(buffer, 0, readyBytes);
+            buffer = Arrays.copyOfRange(buffer, readyBytes, buffer.length);
+            return result;
         } finally {
             lock.unlock();
         }

--- a/src/main/java/io/reticulum/buffer/RawChannelReader.java
+++ b/src/main/java/io/reticulum/buffer/RawChannelReader.java
@@ -116,7 +116,6 @@ public class RawChannelReader extends InputStream {
     public byte[] read(Integer readyBytes) throws IOException {
         lock.lock();
         try {
-            //return Arrays.copyOfRange(buffer, 0, readyBytes);
             var result = Arrays.copyOfRange(buffer, 0, readyBytes);
             buffer = Arrays.copyOfRange(buffer, readyBytes, buffer.length);
             return result;

--- a/src/main/java/io/reticulum/link/Link.java
+++ b/src/main/java/io/reticulum/link/Link.java
@@ -181,6 +181,7 @@ public class Link extends AbstractDestination {
 
     @SneakyThrows
     private void init() {
+        this.lastInbound = Instant.now();
         if (nonNull(destination) && destination.getType() != SINGLE) {
             throw new IllegalArgumentException("Links can only be established to the SINGLE destination type");
         }


### PR DESCRIPTION
Bugs fixed:

1. buffer read still had old content: fixe was to move buffer along on read so that incoming bytes are only read once.
2. Link lastInbound was not initialized: a) this causes a null pointer exception in the Link watchdog timer and b) it also prevents Link packet timeout callback from working. Fix conisists in initializing the property in Link instatiation. => fixes both issues.