### PR TITLE
New Backbone Interface and fixes

### DIFF
--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -753,13 +753,14 @@ public final class Transport implements ExitHandler {
             }
         }
 
+        try {
+
         if (isNull(identity)) {
             return;
         }
 
         var packet = new Packet(localRaw);
         if (isFalse(packet.unpack())) {
-            jobsLock.unlock();
             return;
         }
 
@@ -885,7 +886,6 @@ public final class Transport implements ExitHandler {
                 // If this is a cache request, and we can fullfill it, do so and stop processing. Otherwise resume normal processing.
                 if (packet.getContext() == CACHE_REQUEST) {
                     if (cacheRequestPacket(packet)) {
-                        jobsLock.unlock();
                         return;
                     }
                 }
@@ -1016,7 +1016,6 @@ public final class Transport implements ExitHandler {
                     // by normal announce rate limiting.
                     if (iface.shouldIngressLimit()) {
                         iface.holdAnnounce(packet);
-                        jobsLock.unlock();
                         return;
                     }
                 }
@@ -1606,7 +1605,9 @@ public final class Transport implements ExitHandler {
             }
         }
 
-        jobsLock.unlock();
+        } finally {
+            jobsLock.unlock();
+        }
     }
 
     // TODO: 12.05.2023 подлежит рефакторингу. (subject to refactoring)

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -1629,7 +1629,7 @@ public final class Transport implements ExitHandler {
 
         var sent = false;
         try {
-        var outboundTime = Instant.now();
+            var outboundTime = Instant.now();
 
         var generateReceipt = packet.isCreateReceipt()
                 // Only generate receipts for DATA packets
@@ -1901,7 +1901,11 @@ public final class Transport implements ExitHandler {
             }
         }
 
-        return sent;
+            return sent;
+        } catch (Exception e) {
+            log.error("Exception in outbound() for packet type={} context={}: ",
+                    packet.getPacketType(), packet.getContext(), e);
+            throw e;
         } finally {
             jobsLock.unlock();
         }

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -936,10 +936,11 @@ public final class Transport implements ExitHandler {
                                         .proofTimestamp(proofTimeout)
                                         .build();
 
-//                                linkTable.put(encodeHexString(packet.getTruncatedHash()), linkEntry);
-                                // I changed it to destination Hash, because in java we search by string representation and truncatedHash can be != destinationHash
-                                linkTable.put(encodeHexString(packet.getDestinationHash()), linkEntry);
-                                //linkTable.put(encodeHexString(LinkUtils.linkIdFromLrPacket(packet)), linkEntry);
+                                // Key must be the link ID (truncatedHash of the LINKREQUEST), NOT the destination hash.
+                                // The LRPROOF arrives with destinationHash = Link.linkId = LINKREQUEST.getTruncatedHash(),
+                                // so the lookup at line 1488 uses that value — the store key must match.
+                                // Python equivalent: Transport.link_table[RNS.Link.link_id_from_lr_packet(packet)]
+                                linkTable.put(encodeHexString(packet.getTruncatedHash()), linkEntry);
                             } else {
                                 //Entry format is
                                 var reserveEntry = ReversEntry.builder()
@@ -1522,7 +1523,7 @@ public final class Transport implements ExitHandler {
                                     log.error("Error while transporting link request proof.", e);
                                 }
                             } else {
-                                log.debug("Received link request proof with hop mismatch, not transporting it");
+                                log.debug("Received link request proof on wrong interface, not transporting it");
                             }
                         }
                     } else {

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -1628,6 +1628,7 @@ public final class Transport implements ExitHandler {
         }
 
         var sent = false;
+        try {
         var outboundTime = Instant.now();
 
         var generateReceipt = packet.isCreateReceipt()
@@ -1900,9 +1901,10 @@ public final class Transport implements ExitHandler {
             }
         }
 
-        jobsLock.unlock();
-
         return sent;
+        } finally {
+            jobsLock.unlock();
+        }
     }
 
     /**

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -1537,7 +1537,7 @@ public final class Transport implements ExitHandler {
                                 // be discarded without major issues, but it is kept
                                 // for now to ensure backwards compatibility.
 
-                                if ((packet.getHops() == link.getExpectedHops()) || (link.getExpectedHops() == TransportConstant.PATHFINDER_M )) {
+                                if ((packet.getHops() <= link.getExpectedHops()) || (link.getExpectedHops() == TransportConstant.PATHFINDER_M)) {
                                     // Add this packet to the filter hashlist if we
                                     // have determined that it's actually destined
                                     // for this system, and then validate the proof

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -909,6 +909,12 @@ public final class Transport implements ExitHandler {
                                 dataPacket.getHeader().getFlags().setHeaderType(HEADER_1);
                                 dataPacket.getHeader().getFlags().setPropagationType(BROADCAST);
                                 dataPacket.getHeader().setHops((byte) packet.getHops());
+                                // Packet arrived as HEADER_2 (transport_id | dest_hash).
+                                // When stripping the transport layer, promote dest_hash (hash2)
+                                // into hash1, otherwise the forwarded HEADER_1 packet carries
+                                // the transport ID as the destination address and the recipient
+                                // never recognises it.
+                                dataPacket.getAddresses().setHash1(dataPacket.getAddresses().getHash2());
                             } else if (remainingHops == 0) {
                                 //Just increase hop count and transmit
                                 dataPacket = DataPacketConverter.fromBytes(packet.getRaw());

--- a/src/main/java/io/reticulum/interfaces/AbstractConnectionInterface.java
+++ b/src/main/java/io/reticulum/interfaces/AbstractConnectionInterface.java
@@ -274,7 +274,7 @@ public abstract class AbstractConnectionInterface extends Thread implements Conn
         var hash = Hex.encodeHexString(announcePacket.getDestinationHash());
         if (heldAnnounces.containsKey(hash)) {
             heldAnnounces.put(hash, announcePacket);
-        } else if (MapUtils.size(heldAnnounces) >= icMaxHeldAnnounces) {
+        } else if (isFalse((MapUtils.size(heldAnnounces) >= icMaxHeldAnnounces))) {
             heldAnnounces.put(hash, announcePacket);
         }
     }

--- a/src/main/java/io/reticulum/interfaces/ConnectionInterface.java
+++ b/src/main/java/io/reticulum/interfaces/ConnectionInterface.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.reticulum.identity.Identity;
 import io.reticulum.interfaces.auto.AutoInterface;
+import io.reticulum.interfaces.backbone.BackboneClientInterface;
+import io.reticulum.interfaces.backbone.BackboneServerInterface;
 import io.reticulum.interfaces.tcp.TCPClientInterface;
 import io.reticulum.interfaces.tcp.TCPServerInterface;
 import io.reticulum.packet.Packet;
@@ -23,9 +25,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @JsonSubTypes({
         @Type(value = AutoInterface.class, name = "AutoInterface"),
         @Type(value = TCPClientInterface.class, name = "TCPClientInterface"),
-        @Type(value = TCPServerInterface.class, name = "TCPServerInterface")
+        @Type(value = TCPServerInterface.class, name = "TCPServerInterface"),
+        @Type(value = BackboneClientInterface.class, name = "BackboneClientInterface"),
+        @Type(value = BackboneServerInterface.class, name = "BackboneServerInterface")
 })
 public interface ConnectionInterface {
+
 
     boolean OUT();
     boolean IN();

--- a/src/main/java/io/reticulum/interfaces/auto/AutoInterface.java
+++ b/src/main/java/io/reticulum/interfaces/auto/AutoInterface.java
@@ -257,7 +257,7 @@ public class AutoInterface extends AbstractConnectionInterface implements AutoIn
     }
 
     @Override
-    public synchronized void processIncoming(final byte[] data) {
+    public void processIncoming(final byte[] data) {
         var dataHash = Hex.encodeHexString(fullHash(data));
         if (isFalse(mifDeque.contains(dataHash))) {
             while (mifDeque.size() >= MULTI_IF_DEQUE_LEN) {
@@ -270,7 +270,7 @@ public class AutoInterface extends AbstractConnectionInterface implements AutoIn
     }
 
     @Override
-    public synchronized void processOutgoing(byte[] data) {
+    public void processOutgoing(byte[] data) {
         for (InetAddress peerAddress : peers.keySet()) {
             try (var socket = new DatagramSocket()) {
                 socket.send(new DatagramPacket(data, data.length, peerAddress, dataPort));

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneChannelInitializer.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneChannelInitializer.java
@@ -1,0 +1,89 @@
+package io.reticulum.interfaces.backbone;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.DelimiterBasedFrameDecoder;
+import io.netty.handler.codec.bytes.ByteArrayDecoder;
+import io.netty.handler.codec.bytes.ByteArrayEncoder;
+import io.reticulum.Transport;
+import io.reticulum.interfaces.ConnectionInterface;
+import io.reticulum.interfaces.HDLC;
+import io.reticulum.utils.InterfaceUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Netty channel initializer for Backbone TCP connections.
+ *
+ * <p>Used for both client-initiated connections and server-spawned connections.
+ * HDLC framing with 1 MiB frame limit is configured, and a
+ * {@link BackbonePacketHandler} is added to dispatch incoming frames.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class BackboneChannelInitializer extends ChannelInitializer<SocketChannel> implements HDLC {
+
+    private final ConnectionInterface connectionInterface;
+
+    @Override
+    protected void initChannel(SocketChannel ch) {
+        ch.pipeline().addLast(
+                new DelimiterBasedFrameDecoder(BackboneServerInterface.HW_MTU, true, delimitersHdlc()),
+                new ByteArrayDecoder(),
+                new ByteArrayEncoder(),
+                new BackbonePacketHandler(resolveClientInterface(ch))
+        );
+    }
+
+    /**
+     * Returns the {@link BackboneClientInterface} that should receive frames from
+     * this channel.
+     *
+     * <ul>
+     *   <li>If the owning interface is already a client (initiator mode), return it directly.</li>
+     *   <li>If the owning interface is a server, spawn a new client interface for the
+     *       accepted connection and register it with Transport.</li>
+     * </ul>
+     */
+    private BackboneClientInterface resolveClientInterface(Channel channel) {
+        if (connectionInterface instanceof BackboneClientInterface) {
+            return (BackboneClientInterface) connectionInterface;
+        }
+
+        // Server side — spawn a new interface for this accepted connection
+        var serverInterface = (BackboneServerInterface) connectionInterface;
+
+        var spawned = new BackboneClientInterface(
+                "Client on " + serverInterface.getInterfaceName(),
+                channel,
+                false
+        );
+
+        spawned.setParentInterface(serverInterface);
+        spawned.setIN(serverInterface.isIN());
+        spawned.setOUT(serverInterface.isOUT());
+        spawned.setBitrate(serverInterface.getBitrate());
+        spawned.setAnnounceRateTarget(serverInterface.getAnnounceRateTarget());
+        spawned.setAnnounceRateGrace(serverInterface.getAnnounceRateGrace());
+        spawned.setAnnounceRatePenalty(serverInterface.getAnnounceRatePenalty());
+        spawned.setInterfaceMode(serverInterface.getInterfaceMode());
+        spawned.getOnline().set(true);
+
+        // Copy IFAC credentials from the server interface
+        InterfaceUtils.initIFac(serverInterface);
+        spawned.setIfacNetName(serverInterface.getIfacNetName());
+        spawned.setIfacNetKey(serverInterface.getIfacNetKey());
+        spawned.setIfacKey(serverInterface.getIfacKey());
+        spawned.setIfacSize(serverInterface.getIfacSize());
+        spawned.setIdentity(serverInterface.getIdentity());
+        spawned.setIfacSignature(serverInterface.getIfacSignature());
+
+        log.info("Spawned new BackboneClient Interface: {}", spawned);
+        Transport.getInstance().getInterfaces().add(spawned);
+        serverInterface.getClients().incrementAndGet();
+        serverInterface.spawnedInterfaces.add(spawned);
+
+        return spawned;
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
@@ -307,6 +307,10 @@ public class BackboneClientInterface extends AbstractConnectionInterface impleme
             if (isFalse(neverConnected) && online.get()) {
                 log.info("Reconnected socket for {}", this);
             }
+            // Ensure the interface is still registered with Transport after reconnect.
+            if (!Transport.getInstance().getInterfaces().contains(this)) {
+                Transport.getInstance().getInterfaces().add(this);
+            }
             Transport.getInstance().synthesizeTunnel(this);
         } catch (Exception e) {
             log.debug("Connection attempt {} for {} failed: {}", currentAttempt, this, e.getMessage());

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
@@ -172,7 +172,7 @@ public class BackboneClientInterface extends AbstractConnectionInterface impleme
     // ── Data plane ───────────────────────────────────────────────────────────
 
     @Override
-    public synchronized void processIncoming(byte[] data) {
+    public void processIncoming(byte[] data) {
         var processingData = unmaskHdlc(data);
         rxb.accumulateAndGet(BigInteger.valueOf(processingData.length), BigInteger::add);
 
@@ -185,7 +185,7 @@ public class BackboneClientInterface extends AbstractConnectionInterface impleme
     }
 
     @Override
-    public synchronized void processOutgoing(byte[] data) {
+    public void processOutgoing(byte[] data) {
         log.trace("Backbone send. interface: {}", this);
         if (online.get()) {
             try (var os = new ByteArrayOutputStream()) {

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
@@ -8,11 +8,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundInvoker;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollSocketChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.reticulum.Transport;
 import io.reticulum.interfaces.AbstractConnectionInterface;
 import io.reticulum.interfaces.ConnectionInterface;
@@ -224,9 +219,8 @@ public class BackboneClientInterface extends AbstractConnectionInterface impleme
      * @return {@code true} if the connection was established successfully
      */
     private synchronized boolean connect(final Boolean initial) throws InterruptedException {
-        boolean init      = BooleanUtils.isTrue(initial);
-        boolean useEpoll  = Epoll.isAvailable();
-        EventLoopGroup workerGroup = useEpoll ? new EpollEventLoopGroup() : new NioEventLoopGroup();
+        boolean init       = BooleanUtils.isTrue(initial);
+        EventLoopGroup workerGroup = BackboneTransport.newWorkerGroup();
 
         try {
             if (init) {
@@ -236,7 +230,7 @@ public class BackboneClientInterface extends AbstractConnectionInterface impleme
             var bootstrap = new Bootstrap();
             bootstrap
                     .group(workerGroup)
-                    .channel(useEpoll ? EpollSocketChannel.class : NioSocketChannel.class)
+                    .channel(BackboneTransport.socketChannelClass())
                     .option(ChannelOption.SO_KEEPALIVE, true)
                     .option(ChannelOption.TCP_NODELAY,  true)
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) connectTimeout)

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
@@ -120,7 +120,9 @@ public class BackboneClientInterface extends AbstractConnectionInterface impleme
         this.txb.set(BigInteger.ZERO);
 
         this.IN  = true;
-        this.OUT = false;
+        // OUT stays true (AbstractConnectionInterface default) so Transport will
+        // route outbound packets through this interface.  Python defaults OUT=False
+        // on Interface, but Java defaults OUT=true — don't override it here.
         this.interfaceMode = InterfaceMode.MODE_FULL;
         this.bitrate = BITRATE_GUESS;
 

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneClientInterface.java
@@ -1,0 +1,389 @@
+package io.reticulum.interfaces.backbone;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelOutboundInvoker;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.reticulum.Transport;
+import io.reticulum.interfaces.AbstractConnectionInterface;
+import io.reticulum.interfaces.ConnectionInterface;
+import io.reticulum.interfaces.HDLC;
+import io.reticulum.interfaces.InterfaceMode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.BooleanUtils.isFalse;
+
+/**
+ * BackboneClientInterface — a single TCP connection inside a Backbone transport.
+ *
+ * <p>This class plays two distinct roles:
+ * <ol>
+ *   <li><b>Initiator (client mode)</b> — created directly from configuration with
+ *       {@code target_host} / {@code target_port}; connects to a remote
+ *       {@link BackboneServerInterface} and reconnects automatically on disconnect.</li>
+ *   <li><b>Spawned (server side)</b> — created by {@link BackboneChannelInitializer}
+ *       for every incoming connection accepted by a {@link BackboneServerInterface};
+ *       identified by {@code initiator == false}.</li>
+ * </ol>
+ *
+ * <p>Corresponds to {@code BackboneClientInterface} in the Python reference
+ * implementation (RNS/Interfaces/BackboneInterface.py).
+ *
+ * <p>On Linux, Netty's epoll transport is used automatically when available.
+ * On other platforms the implementation falls back to NIO selectors.
+ *
+ * <p>HDLC framing (FLAG + escaped payload + FLAG) is used, identical to
+ * the TCP interfaces.
+ *
+ * <p>Configuration keys (YAML, client mode only):
+ * <ul>
+ *   <li>{@code target_host}        — remote hostname or IP</li>
+ *   <li>{@code target_port}        — remote TCP port</li>
+ *   <li>{@code connect_timeout}    — initial connect timeout in milliseconds (default 5 000)</li>
+ *   <li>{@code max_reconnect_tries}— max reconnect attempts; {@code null} = unlimited (default)</li>
+ *   <li>{@code prefer_ipv6}        — prefer IPv6 (default {@code false})</li>
+ *   <li>{@code i2p_tunneled}       — mark as I2P-tunnelled (default {@code false})</li>
+ * </ul>
+ */
+@Slf4j
+@Getter
+@Setter
+public class BackboneClientInterface extends AbstractConnectionInterface implements HDLC {
+
+    private static final int  BITRATE_GUESS          = 100_000_000; // 100 Mbit/s
+    private static final long INITIAL_CONNECT_TIMEOUT = 5_000;       // ms
+    private static final long RECONNECT_WAIT          = 5;            // seconds
+
+    // ── Configuration (client / initiator mode) ──────────────────────────────
+
+    @JsonProperty("target_host")
+    private String targetHost;
+
+    @JsonProperty("target_port")
+    private int targetPort;
+
+    @JsonProperty("prefer_ipv6")
+    private boolean preferIpv6 = false;
+
+    @JsonProperty("i2p_tunneled")
+    private boolean i2pTunneled = false;
+
+    @JsonProperty("connect_timeout")
+    private long connectTimeout = INITIAL_CONNECT_TIMEOUT;
+
+    /**
+     * Maximum reconnect attempts before tearing down; {@code null} means unlimited
+     * (matching Python's {@code RECONNECT_MAX_TRIES = None}).
+     */
+    @JsonProperty("max_reconnect_tries")
+    private Integer maxReconnectTries = null;
+
+    // ── Runtime state ────────────────────────────────────────────────────────
+
+    private Timer timer;
+    private ChannelFuture channelFuture;
+    private Channel channel;
+
+    /** {@code true} when this interface originated the connection. */
+    private boolean initiator;
+
+    private volatile boolean reconnecting  = false;
+    private volatile boolean neverConnected = true;
+    private volatile boolean detached      = false;
+
+    /** Set for spawned interfaces created by a {@link BackboneServerInterface}. */
+    private BackboneServerInterface parentInterface;
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    public BackboneClientInterface() {
+        super();
+        this.initiator = true;
+        this.rxb.set(BigInteger.ZERO);
+        this.txb.set(BigInteger.ZERO);
+
+        this.IN  = true;
+        this.OUT = false;
+        this.interfaceMode = InterfaceMode.MODE_FULL;
+        this.bitrate = BITRATE_GUESS;
+
+        if (isNull(ifacSize)) {
+            ifacSize = 16;
+        }
+
+        timer = new Timer(true); // daemon timer
+    }
+
+    /**
+     * Constructor for spawned interfaces (accepted connections on the server side).
+     *
+     * @param name       interface name, e.g. {@code "Client on BackboneServerInterface[…]"}
+     * @param channel    the already-connected Netty channel
+     * @param i2pTunneled whether the parent server is I2P-tunnelled
+     */
+    public BackboneClientInterface(String name, Channel channel, boolean i2pTunneled) {
+        this();
+        this.channel    = channel;
+        this.initiator  = false;
+        this.interfaceName = name;
+        this.maxReconnectTries = 0;
+        this.i2pTunneled = i2pTunneled;
+
+        var remoteAddress = (InetSocketAddress) channel.remoteAddress();
+        targetHost = remoteAddress.getAddress().getHostAddress();
+        targetPort = remoteAddress.getPort();
+    }
+
+    // ── Thread / lifecycle ───────────────────────────────────────────────────
+
+    @Override
+    public void run() {
+        try {
+            connect(initiator);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void launch() {
+        start();
+    }
+
+    // ── Data plane ───────────────────────────────────────────────────────────
+
+    @Override
+    public synchronized void processIncoming(byte[] data) {
+        var processingData = unmaskHdlc(data);
+        rxb.accumulateAndGet(BigInteger.valueOf(processingData.length), BigInteger::add);
+
+        if (nonNull(parentInterface)) {
+            parentInterface.getRxb()
+                    .accumulateAndGet(BigInteger.valueOf(processingData.length), BigInteger::add);
+        }
+
+        Transport.getInstance().inbound(processingData, this);
+    }
+
+    @Override
+    public synchronized void processOutgoing(byte[] data) {
+        log.trace("Backbone send. interface: {}", this);
+        if (online.get()) {
+            try (var os = new ByteArrayOutputStream()) {
+                os.write(FLAG);
+                os.write(escapeHdlc(data));
+                os.write(FLAG);
+
+                getInternalChannel()
+                        .map(ch -> ch.writeAndFlush(os.toByteArray()))
+                        .orElseThrow(() -> new RuntimeException("Channel not present for " + this));
+
+                txb.accumulateAndGet(BigInteger.valueOf(data.length), BigInteger::add);
+
+                if (nonNull(parentInterface)) {
+                    parentInterface.getTxb()
+                            .accumulateAndGet(BigInteger.valueOf(data.length), BigInteger::add);
+                }
+            } catch (Exception e) {
+                log.error("Exception while transmitting via {}, tearing down interface.", this, e);
+                teardown();
+            }
+        }
+    }
+
+    // ── Connection management ────────────────────────────────────────────────
+
+    /**
+     * Opens (or re-opens) the TCP connection.
+     *
+     * <p>Uses epoll on Linux when available, falls back to NIO otherwise.
+     *
+     * @param initial {@code true} for the first connection attempt (controls error verbosity)
+     * @return {@code true} if the connection was established successfully
+     */
+    private synchronized boolean connect(final Boolean initial) throws InterruptedException {
+        boolean init      = BooleanUtils.isTrue(initial);
+        boolean useEpoll  = Epoll.isAvailable();
+        EventLoopGroup workerGroup = useEpoll ? new EpollEventLoopGroup() : new NioEventLoopGroup();
+
+        try {
+            if (init) {
+                log.debug("Establishing Backbone TCP connection for {} …", this);
+            }
+
+            var bootstrap = new Bootstrap();
+            bootstrap
+                    .group(workerGroup)
+                    .channel(useEpoll ? EpollSocketChannel.class : NioSocketChannel.class)
+                    .option(ChannelOption.SO_KEEPALIVE, true)
+                    .option(ChannelOption.TCP_NODELAY,  true)
+                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) connectTimeout)
+                    .handler(new BackboneChannelInitializer(this));
+
+            this.channelFuture = bootstrap.connect(targetHost, targetPort)
+                    .addListener((ChannelFutureListener) future ->
+                            future.channel().closeFuture()
+                                    .addListener((ChannelFutureListener) closeFeature -> {
+                                        online.set(false);
+                                        if (isFalse(detached)) {
+                                            startReconnecting();
+                                        } else {
+                                            workerGroup.shutdownGracefully();
+                                        }
+                                    })
+                    ).sync();
+
+            online.set(channelFuture.channel().isActive());
+            neverConnected = false;
+            log.debug("Backbone TCP connection for {} established.", this);
+
+        } catch (Exception e) {
+            if (init) {
+                log.error("Initial connection for {} could not be established: {}", this, e.getMessage());
+                log.error("Leaving unconnected and retrying connection in {} seconds.", RECONNECT_WAIT);
+                return online.get();
+            } else {
+                throw e;
+            }
+        }
+
+        return online.get();
+    }
+
+    private void startReconnecting() {
+        timer.schedule(new TimerTask() {
+            int attempts = 0;
+
+            @Override
+            public void run() {
+                if (!initiator) {
+                    log.error("Attempt to reconnect on a non-initiator Backbone interface. This should not happen.");
+                    cancel();
+                    return;
+                }
+
+                if (online.get()) {
+                    cancel();
+                    return;
+                }
+
+                if (isFalse(reconnecting)) {
+                    reconnecting = true;
+                } else {
+                    if (maxReconnectTries != null && attempts > maxReconnectTries) {
+                        log.error("Max reconnection attempts reached for {}", BackboneClientInterface.this);
+                        teardown();
+                        cancel();
+                        return;
+                    }
+                    attempts++;
+                    doReconnect(attempts);
+                }
+            }
+        }, 500, Duration.ofSeconds(RECONNECT_WAIT).toMillis());
+    }
+
+    private synchronized void doReconnect(int currentAttempt) {
+        try {
+            reconnecting = !connect(false);
+            if (isFalse(neverConnected) && online.get()) {
+                log.info("Reconnected socket for {}", this);
+            }
+            Transport.getInstance().synthesizeTunnel(this);
+        } catch (Exception e) {
+            log.debug("Connection attempt {} for {} failed: {}", currentAttempt, this, e.getMessage());
+        }
+    }
+
+    // ── Detach / teardown ────────────────────────────────────────────────────
+
+    @Override
+    public synchronized void detach() {
+        var ch = getInternalChannel();
+        if (ch.map(Channel::isActive).orElse(false)) {
+            log.debug("Detaching {}", this);
+            detached = true;
+            try {
+                ch.ifPresent(ChannelOutboundInvoker::close);
+            } catch (Exception e) {
+                log.error("Error while shutting down channel for {}", this, e);
+            }
+            this.channelFuture = null;
+            this.channel = null;
+        }
+    }
+
+    private void teardown() {
+        if (initiator && isFalse(detached)) {
+            log.error("The interface {} experienced an unrecoverable error and is being torn down. "
+                    + "Restart Reticulum to attempt to open this interface again.", this);
+            if (Transport.getInstance().getOwner().isPanicOnIntefaceError()) {
+                System.exit(255);
+            }
+        } else {
+            log.debug("The interface {} is being torn down.", this);
+        }
+
+        online.set(false);
+        OUT = false;
+        IN  = false;
+
+        if (nonNull(parentInterface)) {
+            parentInterface.getClients().decrementAndGet();
+            parentInterface.spawnedInterfaces.remove(this);
+        }
+
+        if (Transport.getInstance().getInterfaces().contains(this) && isFalse(initiator)) {
+            Transport.getInstance().getInterfaces().remove(this);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    @Override
+    public ConnectionInterface getParentInterface() {
+        return parentInterface;
+    }
+
+    private Optional<Channel> getInternalChannel() {
+        return Optional.ofNullable(channelFuture)
+                .map(future -> {
+                    try {
+                        return future.sync().channel();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                })
+                .or(() -> Optional.ofNullable(channel));
+    }
+
+    // ── Object identity ──────────────────────────────────────────────────────
+
+    @Override
+    public String toString() {
+        return getInterfaceName() + "/" + targetHost + ":" + targetPort;
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/backbone/BackbonePacketHandler.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackbonePacketHandler.java
@@ -32,7 +32,13 @@ public class BackbonePacketHandler extends SimpleChannelInboundHandler<byte[]> {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         log.info("BackboneClient Interface {} disconnected.", connectionInterface.getInterfaceName());
         connectionInterface.detach();
-        Transport.getInstance().getInterfaces().remove(connectionInterface);
+
+        // Only remove spawned (non-initiator) interfaces from Transport.
+        // Initiator interfaces stay registered so they can continue to route
+        // traffic after reconnection.
+        if (!connectionInterface.isInitiator()) {
+            Transport.getInstance().getInterfaces().remove(connectionInterface);
+        }
 
         var parent = connectionInterface.getParentInterface();
         if (parent instanceof BackboneServerInterface) {

--- a/src/main/java/io/reticulum/interfaces/backbone/BackbonePacketHandler.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackbonePacketHandler.java
@@ -1,0 +1,60 @@
+package io.reticulum.interfaces.backbone;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.reticulum.Transport;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ArrayUtils;
+
+/**
+ * Netty inbound handler for Backbone TCP frames.
+ *
+ * <p>Forwards decoded HDLC frames to
+ * {@link BackboneClientInterface#processIncoming(byte[])} and handles channel
+ * lifecycle events (disconnect, errors).
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class BackbonePacketHandler extends SimpleChannelInboundHandler<byte[]> {
+
+    private final BackboneClientInterface connectionInterface;
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, byte[] msg) {
+        if (ArrayUtils.isNotEmpty(msg)) {
+            log.trace("channelRead0. context: {}, interface: {}", ctx, connectionInterface);
+            connectionInterface.processIncoming(msg);
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        log.info("BackboneClient Interface {} disconnected.", connectionInterface.getInterfaceName());
+        connectionInterface.detach();
+        Transport.getInstance().getInterfaces().remove(connectionInterface);
+
+        var parent = connectionInterface.getParentInterface();
+        if (parent instanceof BackboneServerInterface) {
+            BackboneServerInterface serverInterface = (BackboneServerInterface) parent;
+            serverInterface.getClients().decrementAndGet();
+            serverInterface.spawnedInterfaces.remove(connectionInterface);
+        }
+
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Error while handling inbound packet in interface {}", connectionInterface, cause);
+        ctx.close();
+    }
+
+    // Compatibility shim for Netty 5 API (channelRead0 → messageReceived)
+    public void messageReceived(ChannelHandlerContext ctx, Object msg) {
+        byte[] message = (byte[]) msg;
+        if (ArrayUtils.isNotEmpty(message)) {
+            connectionInterface.processIncoming(message);
+        }
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneServerInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneServerInterface.java
@@ -141,7 +141,8 @@ public class BackboneServerInterface extends AbstractConnectionInterface impleme
         this.txb.set(BigInteger.ZERO);
 
         this.IN  = true;
-        this.OUT = false;
+        // OUT stays true (AbstractConnectionInterface default), matching TCPServerInterface.
+        // processOutgoing is a no-op; actual sending is done by spawned BackboneClientInterfaces.
         this.interfaceMode = InterfaceMode.MODE_FULL;
         this.bitrate = BITRATE_GUESS;
 

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneServerInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneServerInterface.java
@@ -6,11 +6,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollServerSocketChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.reticulum.interfaces.AbstractConnectionInterface;
 import io.reticulum.interfaces.HDLC;
 import io.reticulum.interfaces.InterfaceMode;
@@ -180,17 +175,16 @@ public class BackboneServerInterface extends AbstractConnectionInterface impleme
      * {@code TCPServerInterface} on other platforms.
      */
     public void startListening() throws InterruptedException {
-        boolean useEpoll = Epoll.isAvailable();
-        EventLoopGroup bossGroup   = useEpoll ? new EpollEventLoopGroup(1) : new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = useEpoll ? new EpollEventLoopGroup()  : new NioEventLoopGroup();
+        EventLoopGroup bossGroup   = BackboneTransport.newBossGroup();
+        EventLoopGroup workerGroup = BackboneTransport.newWorkerGroup();
 
         log.debug("BackboneServerInterface using {} for {}",
-                useEpoll ? "Linux epoll" : "NIO selector", this);
+                BackboneTransport.EPOLL_USABLE ? "Linux epoll" : "NIO selector", this);
 
         var bootstrap = new ServerBootstrap();
         bootstrap
                 .group(bossGroup, workerGroup)
-                .channel(useEpoll ? EpollServerSocketChannel.class : NioServerSocketChannel.class)
+                .channel(BackboneTransport.serverChannelClass())
                 .option(ChannelOption.SO_BACKLOG,  1024)
                 .option(ChannelOption.SO_REUSEADDR, true)
                 .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneServerInterface.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneServerInterface.java
@@ -1,0 +1,275 @@
+package io.reticulum.interfaces.backbone;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.reticulum.interfaces.AbstractConnectionInterface;
+import io.reticulum.interfaces.HDLC;
+import io.reticulum.interfaces.InterfaceMode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+/**
+ * BackboneServerInterface — the listener/server side of a Reticulum Backbone interface.
+ *
+ * <p>Corresponds to {@code BackboneInterface} in the Python reference implementation
+ * (RNS/Interfaces/BackboneInterface.py).
+ *
+ * <p>On Linux, Netty's epoll transport ({@link EpollEventLoopGroup} +
+ * {@link EpollServerSocketChannel}) is used automatically when available, providing
+ * the same scalability benefit as Python's {@code select.epoll}.  On other platforms
+ * the implementation falls back to NIO ({@link NioEventLoopGroup} +
+ * {@link NioServerSocketChannel}), matching the Python fall-back to TCPServerInterface.
+ *
+ * <p>Configuration keys (YAML):
+ * <ul>
+ *   <li>{@code listen_ip}   — IP address to bind to (default {@code "0.0.0.0"})</li>
+ *   <li>{@code listen_port} — TCP port to listen on (required)</li>
+ *   <li>{@code prefer_ipv6} — prefer IPv6 when resolving addresses (default {@code false})</li>
+ * </ul>
+ * Discovery-related configuration keys:
+ * <ul>
+ *   <li>{@code discoverable}                — advertise this interface on the network (default {@code false})</li>
+ *   <li>{@code discovery_name}              — human-readable name to advertise</li>
+ *   <li>{@code reachable_on}                — IP/hostname that remote nodes should connect to</li>
+ *   <li>{@code discovery_announce_interval} — seconds between discovery announces (default 300)</li>
+ *   <li>{@code discovery_stamp_value}       — proof-of-work difficulty (default 14)</li>
+ *   <li>{@code discovery_encrypt}           — encrypt discovery payload (default {@code false})</li>
+ *   <li>{@code discovery_publish_ifac}      — include IFAC credentials in discovery announce (default {@code false})</li>
+ * </ul>
+ */
+@Slf4j
+@Getter
+@Setter
+public class BackboneServerInterface extends AbstractConnectionInterface implements HDLC {
+
+    /** Maximum hardware MTU – 1 MiB, matching Python's {@code HW_MTU}. */
+    public static final int HW_MTU = 1_048_576;
+
+    private static final int BITRATE_GUESS    = 1_000_000_000; // 1 Gbit/s
+    private static final int DEFAULT_IFAC_SIZE = 16;
+
+    // ── Network binding ──────────────────────────────────────────────────────
+
+    @JsonProperty("listen_ip")
+    private String listenIp = "0.0.0.0";
+
+    @JsonProperty("listen_port")
+    private int listenPort;
+
+    @JsonProperty("prefer_ipv6")
+    private boolean preferIpv6 = false;
+
+    // ── Runtime state ────────────────────────────────────────────────────────
+
+    private volatile boolean detached = false;
+    private ChannelFuture channelFuture;
+
+    /** Spawned client interfaces, one per accepted TCP connection. */
+    protected List<BackboneClientInterface> spawnedInterfaces = new CopyOnWriteArrayList<>();
+
+    // ── Discovery ────────────────────────────────────────────────────────────
+
+    /** Whether the interface type supports on-network discovery. Always {@code true}. */
+    private final boolean supportsDiscovery = true;
+
+    /** Whether this instance is configured to actively announce itself. */
+    @JsonProperty("discoverable")
+    private boolean discoverable = false;
+
+    /** Human-readable name to include in discovery announces. */
+    @JsonProperty("discovery_name")
+    private String discoveryName;
+
+    /**
+     * IP address or hostname that remote nodes should use to reach this server.
+     * Can be a literal value or the path to an executable whose stdout provides
+     * the value (non-Windows only, matching Python behaviour).
+     */
+    @JsonProperty("reachable_on")
+    private String reachableOn;
+
+    /** GPS latitude for the discovery announce (optional, default 0.0). */
+    @JsonProperty("discovery_latitude")
+    private double discoveryLatitude = 0.0;
+
+    /** GPS longitude for the discovery announce (optional, default 0.0). */
+    @JsonProperty("discovery_longitude")
+    private double discoveryLongitude = 0.0;
+
+    /** Altitude in metres for the discovery announce (optional, default 0.0). */
+    @JsonProperty("discovery_height")
+    private double discoveryHeight = 0.0;
+
+    /** Proof-of-work difficulty for discovery announces (default 14, matching Python). */
+    @JsonProperty("discovery_stamp_value")
+    private int discoveryStampValue = 14;
+
+    /** Interval between discovery announces in seconds (default 300). */
+    @JsonProperty("discovery_announce_interval")
+    private int discoveryAnnounceInterval = 300;
+
+    /** Epoch-second timestamp of the last sent discovery announce. */
+    private long lastDiscoveryAnnounce = 0;
+
+    /** Whether to encrypt the discovery payload (requires a network identity). */
+    @JsonProperty("discovery_encrypt")
+    private boolean discoveryEncrypt = false;
+
+    /** Whether to include IFAC network name / passphrase in the discovery announce. */
+    @JsonProperty("discovery_publish_ifac")
+    private boolean discoveryPublishIfac = false;
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    public BackboneServerInterface() {
+        super();
+        this.rxb.set(BigInteger.ZERO);
+        this.txb.set(BigInteger.ZERO);
+
+        this.IN  = true;
+        this.OUT = false;
+        this.interfaceMode = InterfaceMode.MODE_FULL;
+        this.bitrate = BITRATE_GUESS;
+
+        if (isNull(ifacSize)) {
+            ifacSize = DEFAULT_IFAC_SIZE;
+        }
+    }
+
+    // ── Thread / lifecycle ───────────────────────────────────────────────────
+
+    @Override
+    public void run() {
+        try {
+            startListening();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void launch() {
+        start();
+    }
+
+    /**
+     * Binds and starts the TCP server.
+     *
+     * <p>Uses epoll when running on Linux (Netty's {@link Epoll#isAvailable()} is
+     * {@code true}), otherwise falls back to NIO selectors — matching the Python
+     * reference which uses {@code select.epoll} on Linux and falls back to
+     * {@code TCPServerInterface} on other platforms.
+     */
+    public void startListening() throws InterruptedException {
+        boolean useEpoll = Epoll.isAvailable();
+        EventLoopGroup bossGroup   = useEpoll ? new EpollEventLoopGroup(1) : new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = useEpoll ? new EpollEventLoopGroup()  : new NioEventLoopGroup();
+
+        log.debug("BackboneServerInterface using {} for {}",
+                useEpoll ? "Linux epoll" : "NIO selector", this);
+
+        var bootstrap = new ServerBootstrap();
+        bootstrap
+                .group(bossGroup, workerGroup)
+                .channel(useEpoll ? EpollServerSocketChannel.class : NioServerSocketChannel.class)
+                .option(ChannelOption.SO_BACKLOG,  1024)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(ChannelOption.TCP_NODELAY, true)
+                .childHandler(new BackboneChannelInitializer(this));
+
+        var bindAddress = (listenIp != null && !listenIp.isEmpty())
+                ? new InetSocketAddress(listenIp, listenPort)
+                : new InetSocketAddress(listenPort);
+
+        this.channelFuture = bootstrap.bind(bindAddress)
+                .addListener((ChannelFutureListener) future ->
+                        future.channel().closeFuture()
+                                .addListener((ChannelFutureListener) closeFeature -> {
+                                    bossGroup.shutdownGracefully();
+                                    workerGroup.shutdownGracefully();
+                                    online.set(false);
+                                })
+                ).sync();
+
+        online.set(true);
+        log.info("BackboneServerInterface [{}] listening on {}:{}", interfaceName, listenIp, listenPort);
+    }
+
+    // ── Data plane ───────────────────────────────────────────────────────────
+
+    @Override
+    public synchronized void processIncoming(byte[] data) {
+        var processingData = unmaskHdlc(data);
+        rxb.accumulateAndGet(BigInteger.valueOf(processingData.length), BigInteger::add);
+        // Inbound data is dispatched by the spawned BackboneClientInterface; this
+        // method is kept for completeness but is not called in the normal path.
+    }
+
+    /**
+     * The server does not send directly; outgoing packets are dispatched by each
+     * spawned {@link BackboneClientInterface}.
+     */
+    @Override
+    public synchronized void processOutgoing(byte[] data) {
+        // pass — handled by spawned interfaces
+    }
+
+    // ── Shutdown ─────────────────────────────────────────────────────────────
+
+    @Override
+    public synchronized void detach() {
+        if (nonNull(channelFuture) && channelFuture.channel().isActive()) {
+            log.debug("Detaching {}", this);
+            detached = true;
+            try {
+                channelFuture.channel().close();
+            } catch (Exception e) {
+                log.error("Error while shutting down channel for {}", this, e);
+            }
+            channelFuture = null;
+        }
+    }
+
+    // ── Announce tracking ────────────────────────────────────────────────────
+
+    @Override
+    public void sentAnnounce(boolean fromSpawned) {
+        if (fromSpawned) {
+            oaFreqDeque.add(0, Instant.now());
+        }
+    }
+
+    @Override
+    public void receivedAnnounce(boolean fromSpawned) {
+        if (fromSpawned) {
+            iaFreqDeque.add(0, Instant.now());
+        }
+    }
+
+    // ── Object identity ──────────────────────────────────────────────────────
+
+    @Override
+    public String toString() {
+        return getInterfaceName() + "/" + listenIp + ":" + listenPort;
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/backbone/BackboneTransport.java
+++ b/src/main/java/io/reticulum/interfaces/backbone/BackboneTransport.java
@@ -1,0 +1,80 @@
+package io.reticulum.interfaces.backbone;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Lazily checks whether Netty's epoll transport can actually be instantiated.
+ *
+ * <p>{@link Epoll#isAvailable()} only verifies that the OS is Linux and the
+ * native library loaded; it does <em>not</em> guarantee that
+ * {@code sun.misc.Unsafe} is accessible for {@code EpollEventArray}, which is
+ * required at runtime.  This helper performs one real instantiation attempt at
+ * class-load time and caches the result so that callers always receive working
+ * event loop groups regardless of JVM configuration.
+ */
+@Slf4j
+final class BackboneTransport {
+
+    /** {@code true} when epoll is both available and functional on this JVM. */
+    static final boolean EPOLL_USABLE = probeEpoll();
+
+    private BackboneTransport() {}
+
+    // ── Factory methods ───────────────────────────────────────────────────────
+
+    /** Creates an {@link EventLoopGroup} with 1 thread, using epoll if usable. */
+    static EventLoopGroup newBossGroup() {
+        if (EPOLL_USABLE) {
+            try { return new EpollEventLoopGroup(1); }
+            catch (Exception e) { log.debug("EpollEventLoopGroup boss fallback: {}", e.getMessage()); }
+        }
+        return new NioEventLoopGroup(1);
+    }
+
+    /** Creates a worker {@link EventLoopGroup} with default thread count, using epoll if usable. */
+    static EventLoopGroup newWorkerGroup() {
+        if (EPOLL_USABLE) {
+            try { return new EpollEventLoopGroup(); }
+            catch (Exception e) { log.debug("EpollEventLoopGroup worker fallback: {}", e.getMessage()); }
+        }
+        return new NioEventLoopGroup();
+    }
+
+    /** Returns the appropriate server channel class. */
+    static Class<? extends ServerSocketChannel> serverChannelClass() {
+        return EPOLL_USABLE ? EpollServerSocketChannel.class : NioServerSocketChannel.class;
+    }
+
+    /** Returns the appropriate client (socket) channel class. */
+    static Class<? extends SocketChannel> socketChannelClass() {
+        return EPOLL_USABLE ? EpollSocketChannel.class : NioSocketChannel.class;
+    }
+
+    // ── Detection ─────────────────────────────────────────────────────────────
+
+    private static boolean probeEpoll() {
+        if (!Epoll.isAvailable()) {
+            return false;
+        }
+        try {
+            EpollEventLoopGroup probe = new EpollEventLoopGroup(1);
+            probe.shutdownGracefully();
+            log.debug("Linux epoll transport available and functional.");
+            return true;
+        } catch (Exception e) {
+            log.debug("Linux epoll reported available but failed to initialise "
+                    + "({}); falling back to NIO.", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/discovery/DiscoveredInterfaceInfo.java
+++ b/src/main/java/io/reticulum/interfaces/discovery/DiscoveredInterfaceInfo.java
@@ -1,0 +1,74 @@
+package io.reticulum.interfaces.discovery;
+
+import lombok.Data;
+
+/**
+ * Immutable data object holding information about a remotely discovered interface.
+ *
+ * <p>Populated by {@link InterfaceAnnounceHandler} when a valid discovery
+ * announce is received, and passed to the registered callback.
+ *
+ * <p>Mirrors the {@code info} dict constructed in Python's
+ * {@code InterfaceAnnounceHandler.received_announce()}.
+ */
+@Data
+public class DiscoveredInterfaceInfo {
+
+    /** Interface type string, e.g. {@code "BackboneInterface"}. */
+    private String type;
+
+    /** Whether the announcing node has transport enabled. */
+    private boolean transport;
+
+    /** Human-readable name advertised by the remote interface. */
+    private String name;
+
+    /** Proof-of-work stamp value (number of leading zero bits). */
+    private int stampValue;
+
+    /** Hex-encoded transport identity hash of the announcing node. */
+    private String transportId;
+
+    /** Hex-encoded network identity hash of the announcing node. */
+    private String networkId;
+
+    /** Number of hops to the announcing destination at the time of receipt. */
+    private int hops;
+
+    /** GPS latitude advertised by the remote interface. */
+    private double latitude;
+
+    /** GPS longitude advertised by the remote interface. */
+    private double longitude;
+
+    /** Altitude in metres advertised by the remote interface. */
+    private double height;
+
+    /** Epoch-second timestamp at which this announce was received. */
+    private long receivedAt;
+
+    /** IP address or hostname to reach the remote interface (TCP types only). */
+    private String reachableOn;
+
+    /** TCP port to reach the remote interface (TCP types only). */
+    private int port;
+
+    /** IFAC network name, if published by the remote interface. */
+    private String ifacNetname;
+
+    /** IFAC passphrase, if published by the remote interface. */
+    private String ifacNetkey;
+
+    /**
+     * A ready-to-paste Reticulum configuration entry snippet for connecting
+     * to this discovered interface.  Only populated for connectable types
+     * ({@code BackboneInterface}, {@code TCPServerInterface}).
+     */
+    private String configEntry;
+
+    /**
+     * SHA-256 hash of {@code (transport_id_hex + name)}, used as a stable
+     * identifier for deduplication.
+     */
+    private byte[] discoveryHash;
+}

--- a/src/main/java/io/reticulum/interfaces/discovery/DiscoveryField.java
+++ b/src/main/java/io/reticulum/interfaces/discovery/DiscoveryField.java
@@ -1,0 +1,65 @@
+package io.reticulum.interfaces.discovery;
+
+/**
+ * Integer keys for the msgpack-encoded interface discovery announce payload.
+ *
+ * <p>These constants mirror the Python reference implementation in
+ * {@code RNS/Discovery.py}.  The packed payload is a msgpack map whose keys
+ * are these single-byte integers; keeping them as bytes rather than strings
+ * minimises wire size.
+ */
+public final class DiscoveryField {
+
+    private DiscoveryField() {}
+
+    /** Human-readable interface name ({@code String}). */
+    public static final int NAME            = 0xFF;
+
+    /** Transport identity hash ({@code byte[]}). */
+    public static final int TRANSPORT_ID    = 0xFE;
+
+    /** Interface type name, e.g. {@code "BackboneInterface"} ({@code String}). */
+    public static final int INTERFACE_TYPE  = 0x00;
+
+    /** Whether the announcing node has transport enabled ({@code boolean}). */
+    public static final int TRANSPORT       = 0x01;
+
+    /** IP address or hostname at which the interface is reachable ({@code String}). */
+    public static final int REACHABLE_ON    = 0x02;
+
+    /** GPS latitude ({@code double}). */
+    public static final int LATITUDE        = 0x03;
+
+    /** GPS longitude ({@code double}). */
+    public static final int LONGITUDE       = 0x04;
+
+    /** Altitude in metres ({@code double}). */
+    public static final int HEIGHT          = 0x05;
+
+    /** TCP/UDP port number ({@code int}). */
+    public static final int PORT            = 0x06;
+
+    /** IFAC network name ({@code String}). */
+    public static final int IFAC_NETNAME    = 0x07;
+
+    /** IFAC passphrase ({@code String}). */
+    public static final int IFAC_NETKEY     = 0x08;
+
+    /** Radio frequency in Hz ({@code long}). */
+    public static final int FREQUENCY       = 0x09;
+
+    /** Radio bandwidth in Hz ({@code long}). */
+    public static final int BANDWIDTH       = 0x0A;
+
+    /** LoRa spreading factor ({@code int}). */
+    public static final int SPREADINGFACTOR = 0x0B;
+
+    /** LoRa coding rate ({@code int}). */
+    public static final int CODINGRATE      = 0x0C;
+
+    /** Radio modulation string ({@code String}). */
+    public static final int MODULATION      = 0x0D;
+
+    /** Radio channel number ({@code int}). */
+    public static final int CHANNEL         = 0x0E;
+}

--- a/src/main/java/io/reticulum/interfaces/discovery/InterfaceAnnounceHandler.java
+++ b/src/main/java/io/reticulum/interfaces/discovery/InterfaceAnnounceHandler.java
@@ -1,0 +1,246 @@
+package io.reticulum.interfaces.discovery;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.reticulum.Transport;
+import io.reticulum.identity.Identity;
+import io.reticulum.transport.AnnounceHandler;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.msgpack.jackson.dataformat.MessagePackMapper;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static io.reticulum.interfaces.discovery.DiscoveryField.HEIGHT;
+import static io.reticulum.interfaces.discovery.DiscoveryField.IFAC_NETKEY;
+import static io.reticulum.interfaces.discovery.DiscoveryField.IFAC_NETNAME;
+import static io.reticulum.interfaces.discovery.DiscoveryField.INTERFACE_TYPE;
+import static io.reticulum.interfaces.discovery.DiscoveryField.LATITUDE;
+import static io.reticulum.interfaces.discovery.DiscoveryField.LONGITUDE;
+import static io.reticulum.interfaces.discovery.DiscoveryField.NAME;
+import static io.reticulum.interfaces.discovery.DiscoveryField.PORT;
+import static io.reticulum.interfaces.discovery.DiscoveryField.REACHABLE_ON;
+import static io.reticulum.interfaces.discovery.DiscoveryField.TRANSPORT;
+import static io.reticulum.interfaces.discovery.DiscoveryField.TRANSPORT_ID;
+import static io.reticulum.utils.IdentityUtils.fullHash;
+
+/**
+ * Handles incoming discovery announces for Reticulum interfaces.
+ *
+ * <p>Corresponds to {@code InterfaceAnnounceHandler} in the Python reference
+ * implementation ({@code RNS/Discovery.py}).
+ *
+ * <h2>Validation pipeline</h2>
+ * <ol>
+ *   <li>Verify that the announcing identity is in the configured list of
+ *       trusted discovery sources (if any).</li>
+ *   <li>Strip the flags byte and, if {@code FLAG_ENCRYPTED}, decrypt the
+ *       payload with the transport's network identity.</li>
+ *   <li>Separate the msgpack payload from the trailing
+ *       {@link LXStamper#STAMP_SIZE}-byte proof-of-work stamp.</li>
+ *   <li>Validate the stamp against the configured {@code requiredValue}.</li>
+ *   <li>Decode the msgpack payload, build a {@link DiscoveredInterfaceInfo}
+ *       record, and pass it to the registered callback.</li>
+ * </ol>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * InterfaceAnnounceHandler handler = new InterfaceAnnounceHandler(14, info -> {
+ *     System.out.println("Discovered: " + info.getConfigEntry());
+ * });
+ * Transport.getInstance().registerAnnounceHandler(handler);
+ * }</pre>
+ */
+@Slf4j
+public class InterfaceAnnounceHandler implements AnnounceHandler {
+
+    /** {@code FLAG_ENCRYPTED} bit in the first byte of the app_data payload. */
+    public static final byte FLAG_ENCRYPTED = 0x02;
+
+    @Getter
+    private final String aspectFilter = InterfaceAnnouncer.APP_NAME + ".discovery.interface";
+
+    private final int requiredValue;
+    private final Consumer<DiscoveredInterfaceInfo> callback;
+    private final ObjectMapper msgpack = new MessagePackMapper();
+
+    /**
+     * @param requiredValue minimum stamp difficulty to accept (default 14)
+     * @param callback      called with parsed info when a valid announce is received;
+     *                      may be {@code null}
+     */
+    public InterfaceAnnounceHandler(int requiredValue, Consumer<DiscoveredInterfaceInfo> callback) {
+        this.requiredValue = requiredValue;
+        this.callback      = callback;
+    }
+
+    public InterfaceAnnounceHandler(Consumer<DiscoveredInterfaceInfo> callback) {
+        this(InterfaceAnnouncer.DEFAULT_STAMP_VALUE, callback);
+    }
+
+    // ── AnnounceHandler ──────────────────────────────────────────────────────
+
+    @Override
+    public void receivedAnnounce(
+            byte[] destinationHash,
+            Identity announcedIdentity,
+            byte[] appData,
+            byte[] announcePacketHash,
+            boolean isPathResponse
+    ) {
+        try {
+            // Check trusted discovery sources (if configured)
+            // Python: if discovery_sources and not announced_identity.hash in discovery_sources: return
+            // TODO: wire up Reticulum.interface_discovery_sources() when that API is added
+
+            if (appData == null || appData.length <= LXStamper.STAMP_SIZE + 1) {
+                log.debug("Ignoring discovery announce with insufficient app_data length.");
+                return;
+            }
+
+            byte   flags     = appData[0];
+            byte[] payload   = new byte[appData.length - 1];
+            System.arraycopy(appData, 1, payload, 0, payload.length);
+
+            boolean encrypted = (flags & FLAG_ENCRYPTED) != 0;
+
+            if (encrypted) {
+                var transport = Transport.getInstance();
+                var netIdentity = transport.getIdentity();
+                if (netIdentity == null) {
+                    log.debug("Received encrypted discovery announce but no network identity available; ignoring.");
+                    return;
+                }
+                payload = netIdentity.decrypt(payload);
+                if (payload == null) {
+                    log.debug("Failed to decrypt discovery announce payload; ignoring.");
+                    return;
+                }
+            }
+
+            if (payload.length <= LXStamper.STAMP_SIZE) {
+                log.debug("Discovery announce payload too short after decryption; ignoring.");
+                return;
+            }
+
+            byte[] stamp  = new byte[LXStamper.STAMP_SIZE];
+            byte[] packed = new byte[payload.length - LXStamper.STAMP_SIZE];
+            System.arraycopy(payload, payload.length - LXStamper.STAMP_SIZE, stamp,  0, LXStamper.STAMP_SIZE);
+            System.arraycopy(payload, 0,                                       packed, 0, packed.length);
+
+            byte[] infohash  = fullHash(packed);
+            byte[] workblock = LXStamper.stampWorkblock(infohash);
+            int    value     = LXStamper.stampValue(workblock, stamp);
+
+            if (!LXStamper.stampValid(stamp, requiredValue, workblock)) {
+                log.debug("Ignored discovered interface with invalid or insufficient stamp (value={}, required={}).",
+                        value, requiredValue);
+                return;
+            }
+
+            // Decode msgpack payload
+            Map<Integer, Object> unpacked = msgpack.readValue(packed, new TypeReference<>() {});
+
+            if (!unpacked.containsKey(INTERFACE_TYPE)) {
+                log.debug("Discovery announce missing INTERFACE_TYPE field; ignoring.");
+                return;
+            }
+
+            String interfaceType = String.valueOf(unpacked.get(INTERFACE_TYPE));
+            DiscoveredInterfaceInfo info = parseInfo(interfaceType, unpacked, announcedIdentity,
+                    destinationHash, value);
+
+            if (info != null && callback != null) {
+                callback.accept(info);
+            }
+
+        } catch (Exception e) {
+            log.debug("An error occurred while decoding discovered interface announce: {}", e.getMessage(), e);
+        }
+    }
+
+    // ── Parsing ──────────────────────────────────────────────────────────────
+
+    private DiscoveredInterfaceInfo parseInfo(
+            String interfaceType,
+            Map<Integer, Object> unpacked,
+            Identity announcedIdentity,
+            byte[] destinationHash,
+            int stampValue
+    ) {
+        String name = unpacked.containsKey(NAME) ? String.valueOf(unpacked.get(NAME)) : "Discovered " + interfaceType;
+        Object transportId = unpacked.get(TRANSPORT_ID);
+        String transportIdHex = transportId instanceof byte[]
+                ? toHex((byte[]) transportId)
+                : String.valueOf(transportId);
+        String networkIdHex = toHex(announcedIdentity.getHash());
+
+        var info = new DiscoveredInterfaceInfo();
+        info.setType(interfaceType);
+        info.setTransport(Boolean.TRUE.equals(unpacked.get(TRANSPORT)));
+        info.setName(name);
+        info.setStampValue(stampValue);
+        info.setTransportId(transportIdHex);
+        info.setNetworkId(networkIdHex);
+        info.setHops(Transport.getInstance().hopsTo(destinationHash));
+        info.setLatitude(toDouble(unpacked.get(LATITUDE)));
+        info.setLongitude(toDouble(unpacked.get(LONGITUDE)));
+        info.setHeight(toDouble(unpacked.get(HEIGHT)));
+        info.setReceivedAt(System.currentTimeMillis() / 1000L);
+
+        if (unpacked.containsKey(IFAC_NETNAME)) info.setIfacNetname(String.valueOf(unpacked.get(IFAC_NETNAME)));
+        if (unpacked.containsKey(IFAC_NETKEY))  info.setIfacNetkey(String.valueOf(unpacked.get(IFAC_NETKEY)));
+
+        if ("BackboneInterface".equals(interfaceType) || "TCPServerInterface".equals(interfaceType)) {
+            String reachableOn = String.valueOf(unpacked.get(REACHABLE_ON));
+            int    port        = toInt(unpacked.get(PORT));
+            info.setReachableOn(reachableOn);
+            info.setPort(port);
+
+            // Decide connection type: BackboneInterface on Linux/Android, TCPClientInterface otherwise
+            boolean isLinux    = System.getProperty("os.name", "").toLowerCase().contains("linux")
+                              || System.getProperty("os.name", "").toLowerCase().contains("android");
+            String connType    = isLinux ? "BackboneInterface" : "TCPClientInterface";
+            String remoteField = isLinux ? "remote"            : "target_host";
+
+            StringBuilder cfg = new StringBuilder();
+            cfg.append("[[").append(info.getName()).append("]]\n");
+            cfg.append("  type = ").append(connType).append("\n");
+            cfg.append("  enabled = yes\n");
+            cfg.append("  ").append(remoteField).append(" = ").append(reachableOn).append("\n");
+            cfg.append("  target_port = ").append(port).append("\n");
+            cfg.append("  transport_identity = ").append(transportIdHex).append("\n");
+            if (info.getIfacNetname() != null) cfg.append("  network_name = ").append(info.getIfacNetname()).append("\n");
+            if (info.getIfacNetkey()  != null) cfg.append("  passphrase = ").append(info.getIfacNetkey()).append("\n");
+            info.setConfigEntry(cfg.toString());
+        }
+
+        // Build discovery hash from transport_id + name (matching Python reference)
+        byte[] hashMaterial = (transportIdHex + name).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        info.setDiscoveryHash(fullHash(hashMaterial));
+
+        return info;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static String toHex(byte[] bytes) {
+        if (bytes == null) return "";
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) sb.append(String.format("%02x", b));
+        return sb.toString();
+    }
+
+    private static double toDouble(Object o) {
+        if (o == null) return 0.0;
+        if (o instanceof Number) return ((Number) o).doubleValue();
+        try { return Double.parseDouble(o.toString()); } catch (Exception e) { return 0.0; }
+    }
+
+    private static int toInt(Object o) {
+        if (o == null) return 0;
+        if (o instanceof Number) return ((Number) o).intValue();
+        try { return Integer.parseInt(o.toString()); } catch (Exception e) { return 0; }
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/discovery/InterfaceAnnouncer.java
+++ b/src/main/java/io/reticulum/interfaces/discovery/InterfaceAnnouncer.java
@@ -1,0 +1,265 @@
+package io.reticulum.interfaces.discovery;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.reticulum.Transport;
+import io.reticulum.destination.Destination;
+import io.reticulum.destination.DestinationType;
+import io.reticulum.destination.Direction;
+import io.reticulum.interfaces.backbone.BackboneServerInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.msgpack.jackson.dataformat.MessagePackMapper;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.reticulum.interfaces.discovery.DiscoveryField.HEIGHT;
+import static io.reticulum.interfaces.discovery.DiscoveryField.IFAC_NETKEY;
+import static io.reticulum.interfaces.discovery.DiscoveryField.IFAC_NETNAME;
+import static io.reticulum.interfaces.discovery.DiscoveryField.INTERFACE_TYPE;
+import static io.reticulum.interfaces.discovery.DiscoveryField.LATITUDE;
+import static io.reticulum.interfaces.discovery.DiscoveryField.LONGITUDE;
+import static io.reticulum.interfaces.discovery.DiscoveryField.NAME;
+import static io.reticulum.interfaces.discovery.DiscoveryField.PORT;
+import static io.reticulum.interfaces.discovery.DiscoveryField.REACHABLE_ON;
+import static io.reticulum.interfaces.discovery.DiscoveryField.TRANSPORT;
+import static io.reticulum.interfaces.discovery.DiscoveryField.TRANSPORT_ID;
+import static io.reticulum.utils.IdentityUtils.fullHash;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * Periodically broadcasts signed, proof-of-work-stamped discovery announces for
+ * discoverable {@link BackboneServerInterface} instances.
+ *
+ * <p>Corresponds to {@code InterfaceAnnouncer} in the Python reference
+ * implementation ({@code RNS/Discovery.py}).
+ *
+ * <h2>Wire format</h2>
+ * Each announce's {@code app_data} is:
+ * <pre>
+ *   flags (1 byte) ‖ payload
+ * </pre>
+ * where {@code payload = msgpack(info) ‖ stamp} and
+ * {@code stamp} is an {@link LXStamper#STAMP_SIZE}-byte proof-of-work nonce.
+ * When the {@code FLAG_ENCRYPTED} flag is set the payload is encrypted with the
+ * network identity before being appended to the flags byte.
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * InterfaceAnnouncer announcer = new InterfaceAnnouncer(transport);
+ * announcer.start();
+ * }</pre>
+ */
+@Slf4j
+public class InterfaceAnnouncer {
+
+    /** Seconds between each job cycle. */
+    public static final int JOB_INTERVAL = 60;
+
+    /** Default proof-of-work difficulty (leading zero bits). */
+    public static final int DEFAULT_STAMP_VALUE = 14;
+
+    /** {@code FLAG_ENCRYPTED} bit in the first byte of the app_data payload. */
+    public static final byte FLAG_ENCRYPTED = 0x02;
+
+    static final String APP_NAME = "rnstransport";
+
+    private final Transport transport;
+    private final Destination discoveryDestination;
+    private final ObjectMapper msgpack = new MessagePackMapper();
+    private final Map<String, byte[]> stampCache = new HashMap<>();
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private ScheduledExecutorService scheduler;
+
+    public InterfaceAnnouncer(Transport transport) {
+        this.transport = transport;
+
+        var identity = transport.getIdentity();
+        this.discoveryDestination = new Destination(
+                identity, Direction.IN, DestinationType.SINGLE,
+                APP_NAME, "discovery", "interface"
+        );
+    }
+
+    /** Starts the periodic announcement job. */
+    public void start() {
+        if (running.compareAndSet(false, true)) {
+            scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "InterfaceAnnouncer");
+                t.setDaemon(true);
+                return t;
+            });
+            scheduler.scheduleAtFixedRate(this::job, JOB_INTERVAL, JOB_INTERVAL, TimeUnit.SECONDS);
+            log.debug("InterfaceAnnouncer started.");
+        }
+    }
+
+    /** Stops the periodic announcement job. */
+    public void stop() {
+        if (running.compareAndSet(true, false) && nonNull(scheduler)) {
+            scheduler.shutdown();
+        }
+    }
+
+    // ── Periodic job ─────────────────────────────────────────────────────────
+
+    private void job() {
+        try {
+            long now = Instant.now().getEpochSecond();
+
+            // Find discoverable BackboneServerInterfaces that are due for an announce
+            transport.getInterfaces().stream()
+                    .filter(i -> i instanceof BackboneServerInterface)
+                    .map(i -> (BackboneServerInterface) i)
+                    .filter(BackboneServerInterface::isDiscoverable)
+                    .filter(i -> now > i.getLastDiscoveryAnnounce() + i.getDiscoveryAnnounceInterval())
+                    .max((a, b) -> Long.compare(
+                            now - a.getLastDiscoveryAnnounce(),
+                            now - b.getLastDiscoveryAnnounce()))
+                    .ifPresent(iface -> {
+                        iface.setLastDiscoveryAnnounce(now);
+                        log.debug("Preparing interface discovery announce for {}", iface.getInterfaceName());
+                        byte[] appData = buildAnnounceData(iface);
+                        if (appData == null) {
+                            log.error("Could not generate interface discovery announce data for {}",
+                                    iface.getInterfaceName());
+                        } else {
+                            log.debug("Sending interface discovery announce for {} ({} bytes payload)",
+                                    iface.getInterfaceName(), appData.length);
+                            discoveryDestination.announce(appData);
+                        }
+                    });
+        } catch (Exception e) {
+            log.error("Error while preparing interface discovery announces: {}", e.getMessage(), e);
+        }
+    }
+
+    // ── Payload construction ─────────────────────────────────────────────────
+
+    /**
+     * Builds the full {@code app_data} bytes for a discovery announce.
+     *
+     * @param iface the interface to announce
+     * @return the serialised payload, or {@code null} on error
+     */
+    byte[] buildAnnounceData(BackboneServerInterface iface) {
+        try {
+            String reachableOn = resolveReachableOn(iface);
+            if (reachableOn == null) return null;
+
+            Map<Integer, Object> info = new HashMap<>();
+            info.put(INTERFACE_TYPE, "BackboneInterface");
+            info.put(TRANSPORT,      transport.getOwner().isTransportEnabled());
+            info.put(TRANSPORT_ID,   transport.getIdentity().getHash());
+            info.put(NAME,           sanitize(iface.getDiscoveryName()));
+            info.put(LATITUDE,       iface.getDiscoveryLatitude());
+            info.put(LONGITUDE,      iface.getDiscoveryLongitude());
+            info.put(HEIGHT,         iface.getDiscoveryHeight());
+            info.put(REACHABLE_ON,   reachableOn);
+            info.put(PORT,           iface.getListenPort());
+
+            if (iface.isDiscoveryPublishIfac()) {
+                if (isNotBlank(iface.getIfacNetName())) info.put(IFAC_NETNAME, iface.getIfacNetName());
+                if (isNotBlank(iface.getIfacNetKey()))  info.put(IFAC_NETKEY,  iface.getIfacNetKey());
+            }
+
+            byte[] packed   = msgpack.writeValueAsBytes(info);
+            byte[] infohash = fullHash(packed);
+
+            // Check stamp cache to avoid regenerating expensive PoW for unchanged info
+            String cacheKey = toHex(infohash);
+            byte[] stamp = stampCache.get(cacheKey);
+            if (stamp == null) {
+                int stampCost = iface.getDiscoveryStampValue() > 0
+                        ? iface.getDiscoveryStampValue()
+                        : DEFAULT_STAMP_VALUE;
+                stamp = LXStamper.generateStamp(infohash, stampCost);
+                if (stamp == null) return null;
+                stampCache.put(cacheKey, stamp);
+            }
+
+            byte flags   = 0x00;
+            byte[] payload;
+
+            if (iface.isDiscoveryEncrypt()) {
+                flags |= FLAG_ENCRYPTED;
+                // Encryption requires a network identity; use Transport identity as fallback
+                var networkIdentity = transport.getIdentity();
+                if (networkIdentity == null) {
+                    log.error("Discovery encryption requested for {} but no network identity available. "
+                            + "Aborting discovery announce.", iface);
+                    return null;
+                }
+                byte[] plaintext = concat(packed, stamp);
+                payload = networkIdentity.encrypt(plaintext);
+            } else {
+                payload = concat(packed, stamp);
+            }
+
+            return concat(new byte[]{flags}, payload);
+
+        } catch (Exception e) {
+            log.error("Error building discovery announce data for {}: {}", iface, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Resolves the {@code reachable_on} value.  On Linux this may be an
+     * executable path whose stdout provides the address; on all platforms a
+     * literal IP/hostname is accepted.
+     */
+    private String resolveReachableOn(BackboneServerInterface iface) {
+        String raw = iface.getReachableOn();
+        if (raw == null || raw.isBlank()) {
+            log.error("No reachable_on configured for {}, aborting discovery announce.", iface);
+            return null;
+        }
+        String resolved = sanitize(raw);
+        if (!isValidAddress(resolved)) {
+            log.error("The configured reachable_on \"{}\" for {} is not a valid IP or hostname. "
+                    + "Aborting discovery announce.", resolved, iface);
+            return null;
+        }
+        return resolved;
+    }
+
+    private static boolean isValidAddress(String s) {
+        if (s == null || s.isBlank()) return false;
+        // Accept plain hostnames / IP addresses
+        // A simple heuristic: try to parse as InetAddress, or accept valid hostname chars
+        try {
+            InetAddress.getByName(s);
+            return true;
+        } catch (Exception e) {
+            // Allow valid hostname patterns (letters, digits, dots, hyphens)
+            return s.matches("[A-Za-z0-9]([A-Za-z0-9\\-\\.]*[A-Za-z0-9])?");
+        }
+    }
+
+    private static String sanitize(String s) {
+        if (s == null) return "";
+        return s.replace("\n", "").replace("\r", "").strip();
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] result = new byte[a.length + b.length];
+        System.arraycopy(a, 0, result, 0, a.length);
+        System.arraycopy(b, 0, result, a.length, b.length);
+        return result;
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) sb.append(String.format("%02x", b));
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/discovery/LXStamper.java
+++ b/src/main/java/io/reticulum/interfaces/discovery/LXStamper.java
@@ -1,0 +1,174 @@
+package io.reticulum.interfaces.discovery;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/**
+ * Proof-of-work stamp generator / validator compatible with the Python
+ * {@code LXStamper} from the LXMF package.
+ *
+ * <h2>Algorithm overview</h2>
+ * <ol>
+ *   <li>Compute the <em>workblock</em> by iterating SHA-256 over the infohash
+ *       {@code EXPAND_ROUNDS} (20) times.  This makes stamp generation more
+ *       memory-hard than a plain hash chain.</li>
+ *   <li>To <em>generate</em> a stamp, search for a random 8-byte nonce
+ *       {@code s} such that the leading bit-count of
+ *       {@code SHA256(workblock ‖ s)} is ≥ {@code required_value}.</li>
+ *   <li>To <em>validate</em> a stamp, compute
+ *       {@code SHA256(workblock ‖ stamp)}, count leading zero bits, and
+ *       check against {@code required_value}.</li>
+ * </ol>
+ *
+ * <p><b>Compatibility note:</b> The LXMF {@code LXStamper} algorithm is not
+ * formally documented.  The above description is derived from the observable
+ * behaviour of the Python code.  If the Python LXMF package is ever updated
+ * this implementation may need adjustment.  In particular {@link #STAMP_SIZE}
+ * must match {@code LXStamper.STAMP_SIZE} exactly for interoperability.
+ */
+@Slf4j
+public final class LXStamper {
+
+    /**
+     * Size of a proof-of-work stamp in bytes.
+     * Must match {@code LXStamper.STAMP_SIZE} in Python's LXMF package.
+     */
+    public static final int STAMP_SIZE = 8;
+
+    /**
+     * Number of SHA-256 iterations used to derive the workblock from the
+     * infohash.  Matches {@code InterfaceAnnouncer.WORKBLOCK_EXPAND_ROUNDS = 20}
+     * in the Python reference.
+     */
+    public static final int EXPAND_ROUNDS = 20;
+
+    private static final SecureRandom RNG = new SecureRandom();
+
+    private LXStamper() {}
+
+    // ── Workblock ─────────────────────────────────────────────────────────────
+
+    /**
+     * Expands an infohash into a workblock by iterating SHA-256
+     * {@link #EXPAND_ROUNDS} times.
+     *
+     * @param infohash the 32-byte SHA-256 hash of the packed info payload
+     * @return the derived 32-byte workblock
+     */
+    public static byte[] stampWorkblock(byte[] infohash) {
+        return stampWorkblock(infohash, EXPAND_ROUNDS);
+    }
+
+    /**
+     * Expands an infohash into a workblock by iterating SHA-256
+     * {@code expandRounds} times.
+     *
+     * @param infohash     the 32-byte SHA-256 hash of the packed info payload
+     * @param expandRounds number of SHA-256 iterations
+     * @return the derived 32-byte workblock
+     */
+    public static byte[] stampWorkblock(byte[] infohash, int expandRounds) {
+        byte[] current = Arrays.copyOf(infohash, infohash.length);
+        var digest = new SHA256Digest();
+        for (int i = 0; i < expandRounds; i++) {
+            digest.reset();
+            digest.update(current, 0, current.length);
+            byte[] next = new byte[digest.getDigestSize()];
+            digest.doFinal(next, 0);
+            current = next;
+        }
+        return current;
+    }
+
+    // ── Value measurement ─────────────────────────────────────────────────────
+
+    /**
+     * Measures the "value" of a stamp as the number of leading zero bits in
+     * {@code SHA256(workblock ‖ stamp)}.
+     *
+     * @param workblock the 32-byte workblock derived from the infohash
+     * @param stamp     the candidate stamp bytes (must be {@link #STAMP_SIZE} bytes)
+     * @return number of leading zero bits
+     */
+    public static int stampValue(byte[] workblock, byte[] stamp) {
+        var digest = new SHA256Digest();
+        digest.update(workblock, 0, workblock.length);
+        digest.update(stamp, 0, stamp.length);
+        byte[] result = new byte[digest.getDigestSize()];
+        digest.doFinal(result, 0);
+        return countLeadingZeroBits(result);
+    }
+
+    /**
+     * Returns {@code true} if the stamp's value meets {@code requiredValue}.
+     *
+     * @param stamp         the stamp to validate
+     * @param requiredValue minimum number of leading zero bits required
+     * @param workblock     the workblock to validate against
+     * @return {@code true} if valid
+     */
+    public static boolean stampValid(byte[] stamp, int requiredValue, byte[] workblock) {
+        return stampValue(workblock, stamp) >= requiredValue;
+    }
+
+    // ── Generation ────────────────────────────────────────────────────────────
+
+    /**
+     * Generates a proof-of-work stamp for {@code infohash} with a difficulty of
+     * {@code stampCost} leading zero bits.
+     *
+     * <p>This is a CPU-bound operation whose expected running time grows
+     * exponentially with {@code stampCost}.  At the default value of 14 it
+     * typically completes in well under a second.
+     *
+     * @param infohash  the 32-byte SHA-256 hash of the packed info payload
+     * @param stampCost required number of leading zero bits
+     * @return a {@link #STAMP_SIZE}-byte nonce satisfying the difficulty, or
+     *         {@code null} if stamp generation failed unexpectedly
+     */
+    public static byte[] generateStamp(byte[] infohash, int stampCost) {
+        return generateStamp(infohash, stampCost, EXPAND_ROUNDS);
+    }
+
+    /**
+     * Generates a proof-of-work stamp.
+     *
+     * @param infohash     the 32-byte SHA-256 hash of the packed info payload
+     * @param stampCost    required number of leading zero bits
+     * @param expandRounds number of workblock expansion rounds
+     * @return a satisfying stamp, or {@code null} on failure
+     */
+    public static byte[] generateStamp(byte[] infohash, int stampCost, int expandRounds) {
+        byte[] workblock = stampWorkblock(infohash, expandRounds);
+        byte[] stamp     = new byte[STAMP_SIZE];
+
+        while (true) {
+            RNG.nextBytes(stamp);
+            if (stampValue(workblock, stamp) >= stampCost) {
+                return Arrays.copyOf(stamp, stamp.length);
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static int countLeadingZeroBits(byte[] data) {
+        int count = 0;
+        for (byte b : data) {
+            if (b == 0) {
+                count += 8;
+            } else {
+                int mask = 0x80;
+                while ((b & mask) == 0) {
+                    count++;
+                    mask >>= 1;
+                }
+                break;
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/io/reticulum/interfaces/local/LocalClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/local/LocalClientInterface.java
@@ -195,7 +195,7 @@ public class LocalClientInterface extends AbstractConnectionInterface implements
     }
 
     @Override
-    public synchronized void processIncoming(byte[] data) {
+    public void processIncoming(byte[] data) {
         if (forceBitrate) {
             try {
                 Thread.sleep(TimeUnit.SECONDS.toMillis(data.length / bitrate * 8L));
@@ -211,7 +211,7 @@ public class LocalClientInterface extends AbstractConnectionInterface implements
         Transport.getInstance().inbound(data, this);
     }
 
-    public synchronized void processOutgoing(final byte[] data) {
+    public void processOutgoing(final byte[] data) {
         if (online.get()) {
             try {
                 var outputStream = new DataOutputStream(socket.getOutputStream());

--- a/src/main/java/io/reticulum/interfaces/tcp/PacketInboundHandler.java
+++ b/src/main/java/io/reticulum/interfaces/tcp/PacketInboundHandler.java
@@ -25,9 +25,15 @@ public class PacketInboundHandler extends SimpleChannelInboundHandler<byte[]> {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         log.info("TCPClient Interface: {} is disconnected", connectionInterface.getInterfaceName());
         connectionInterface.detach();
-        Transport.getInstance().getInterfaces().remove(connectionInterface);
-        TCPServerInterface parentInterface = connectionInterface.getParentInterface();
-        if (parentInterface != null) parentInterface.getClients().decrementAndGet();
+
+        // Only remove spawned (non-initiator) interfaces from Transport.
+        // Initiator interfaces stay registered so they can continue to route
+        // traffic after reconnection.
+        if (!connectionInterface.isInitiator()) {
+            Transport.getInstance().getInterfaces().remove(connectionInterface);
+            TCPServerInterface parentInterface = connectionInterface.getParentInterface();
+            if (parentInterface != null) parentInterface.getClients().decrementAndGet();
+        }
 
         super.channelInactive(ctx);
     }

--- a/src/main/java/io/reticulum/interfaces/tcp/TCPClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/tcp/TCPClientInterface.java
@@ -126,7 +126,7 @@ public class TCPClientInterface extends AbstractConnectionInterface implements H
     }
 
     @Override
-    public synchronized void processIncoming(byte[] data) {
+    public void processIncoming(byte[] data) {
         var processingData = kissFraming ? unmaskKiss(data) : unmaskHdlc(data);
         this.rxb.accumulateAndGet(BigInteger.valueOf(processingData.length), BigInteger::add);
         if (nonNull(parentInterface)) {
@@ -138,7 +138,7 @@ public class TCPClientInterface extends AbstractConnectionInterface implements H
     }
 
     @Override
-    public synchronized void processOutgoing(byte[] data) {
+    public void processOutgoing(byte[] data) {
         log.trace("Send packet data. interface: {}, message: {}", this, data);
         if (online.get()) {
             try(var os = new ByteArrayOutputStream()) {

--- a/src/main/java/io/reticulum/interfaces/tcp/TCPClientInterface.java
+++ b/src/main/java/io/reticulum/interfaces/tcp/TCPClientInterface.java
@@ -206,6 +206,10 @@ public class TCPClientInterface extends AbstractConnectionInterface implements H
             if (isFalse(neverConnected) && online.get()) {
                 log.info("Reconnected socket for {}", this);
             }
+            // Ensure the interface is still registered with Transport after reconnect.
+            if (!Transport.getInstance().getInterfaces().contains(this)) {
+                Transport.getInstance().getInterfaces().add(this);
+            }
             if (isFalse(kissFraming)) {
                 Transport.getInstance().synthesizeTunnel(this);
             }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="TRACE">
+        <Root level="debug">
             <AppenderRef ref="Console" />
         </Root>
     </Loggers>


### PR DESCRIPTION
New Backbone Interface, fixes and more alignement with Python version.

Changes include:

* New *BackboneClientInterface* and *BackboneServerInterface*
  => more scalable, uses epoll kernel feature on linux
  => higher band with
  => alternatives to TCP{Client,Server}Interface.
* fixes to client interfaces reconnect when server interface is restarted
* implemented interface discoverability
* fixes to locking, instances where cross thread locking prevented lock release
* fixes to Transport logic, aligned with Python version
* fixes to routing via destination propagation
* fixes to link table entry (truncatedHash)