### PR TITLE
Refactor Buffer and other stability fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.13.Final</version>
+                <version>4.2.14.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.14.Final</version>
+                <version>4.2.15.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -1727,12 +1727,16 @@ public final class Transport implements ExitHandler {
         }
 
         } finally {
+            // Unlock BEFORE logging: log.warn() allocates (string format + autoboxing) and can
+            // itself throw OutOfMemoryError under heap pressure, which would skip unlock() and
+            // leak the lock forever. Capture timing into primitives first, release the lock,
+            // then log.
             long inboundHeldMs = System.currentTimeMillis() - inboundLockAcquiredAt;
-            if (inboundHeldMs > 200) {
-                log.warn("inbound() held jobsLock for {}ms (thread={})", inboundHeldMs, Thread.currentThread().getName());
-            }
             if (jobsLock.isHeldByCurrentThread()) {
                 jobsLock.unlock();
+            }
+            if (inboundHeldMs > 200) {
+                log.warn("inbound() held jobsLock for {}ms (thread={})", inboundHeldMs, Thread.currentThread().getName());
             }
             // Flush deferred I/O AFTER releasing jobsLock to prevent ABBA deadlock:
             // processOutgoing → channel.send acquires channel.lock; if jobsLock were still
@@ -2056,13 +2060,17 @@ public final class Transport implements ExitHandler {
                     packet.getPacketType(), packet.getContext(), e);
             throw e;
         } finally {
+            // Unlock BEFORE logging: log.warn() allocates (string format + autoboxing) and can
+            // itself throw OutOfMemoryError under heap pressure, which would skip unlock() and
+            // leak the lock forever. Capture timing into primitives first, release the lock,
+            // then log.
             long heldMs = System.currentTimeMillis() - lockAcquiredAt;
+            jobsLock.unlock();
             if (heldMs > 200) {
                 log.warn("outbound() held jobsLock for {}ms (thread={}, pkt={})",
                         heldMs, Thread.currentThread().getName(),
                         packet.getPacketType());
             }
-            jobsLock.unlock();
         }
     }
 
@@ -3210,14 +3218,18 @@ public final class Transport implements ExitHandler {
             } catch (Exception e) {
                 log.error("An exception occurred while running Transport jobs.", e);
             } finally {
+                // Unlock BEFORE logging: log.warn() allocates (string format + autoboxing) and can
+                // itself throw OutOfMemoryError under heap pressure, which would skip unlock() and
+                // leak the lock forever. Capture timing into primitives first, release the lock,
+                // then log.
                 long jobsHeldMs = System.currentTimeMillis() - jobsLockAcquiredAt;
-                if (jobsHeldMs > 200) {
-                    log.warn("jobs() held jobsLock for {}ms (thread={})", jobsHeldMs, Thread.currentThread().getName());
-                }
                 try {
                     jobsLock.unlock();
-                } catch (IllegalStateException e) {
-                    log.warn("Error while jobsLock unlock", e);
+                } catch (IllegalMonitorStateException e) {
+                    log.warn("jobsLock unlock failed (not held by current thread)", e);
+                }
+                if (jobsHeldMs > 200) {
+                    log.warn("jobs() held jobsLock for {}ms (thread={})", jobsHeldMs, Thread.currentThread().getName());
                 }
             }
         } else {

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -2957,9 +2957,15 @@ public final class Transport implements ExitHandler {
 
                 //Cull the path request tags list if it has reached its max size
                 if (discoveryPrTags.size() > MAX_PR_TAGS) {
-                    var list = discoveryPrTags.subList(discoveryPrTags.size() - MAX_PR_TAGS, discoveryPrTags.size() - 1);
+                    // Copy the tail into an independent list BEFORE clearing.
+                    // subList() returns a live view into the backing CopyOnWriteArrayList;
+                    // clear() then invalidates the view and the subsequent addAll(view)
+                    // throws ConcurrentModificationException, aborting the whole jobs() run.
+                    var keep = new ArrayList<>(discoveryPrTags.subList(
+                            discoveryPrTags.size() - MAX_PR_TAGS,
+                            discoveryPrTags.size() - 1));
                     discoveryPrTags.clear();
-                    discoveryPrTags.addAll(list);
+                    discoveryPrTags.addAll(keep);
                 }
 
                 if (Instant.now().isAfter(tablesLastCulled.get().plusMillis(TABLES_CULL_INTERVAL))) {

--- a/src/main/java/io/reticulum/buffer/RawChannelReader.java
+++ b/src/main/java/io/reticulum/buffer/RawChannelReader.java
@@ -7,45 +7,51 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-
-import static io.reticulum.utils.IdentityUtils.concatArrays;
-
-//import io.netty.channel.ChannelException;
-//import io.reticulum.channel.RChannelException;
-;
 
 @Slf4j
 public class RawChannelReader extends InputStream {
     /**
      * Hard cap on the inbound buffer per stream. When exceeded we drop further
      * incoming data and mark the stream EOF so consumers stop. Without this cap
-     * a misbehaving (or simply faster-than-consumer) peer can drive
-     * {@code buffer = concatArrays(buffer, ...)} to OutOfMemoryError, which has
-     * been observed on public-facing nodes and propagates up into
-     * {@code Transport.inbound()}.
+     * a misbehaving (or simply faster-than-consumer) peer can drive the buffer
+     * to OutOfMemoryError, which has been observed on public-facing nodes and
+     * propagates up into {@code Transport.inbound()}.
      *
      * Override via {@code -Dio.reticulum.buffer.maxSize=<bytes>}.
      */
     public static final int MAX_BUFFER_SIZE =
             Integer.getInteger("io.reticulum.buffer.maxSize", 8 * 1024 * 1024); // 8 MiB
+
     private final int streamId;
     private final Channel channel;
     private final ReentrantLock lock = new ReentrantLock();
     private List<Consumer<Integer>> listeners;
     private StreamDataMessage sdm = new StreamDataMessage();
-    private byte[] buffer;
+
+    // Chunked buffer: incoming StreamDataMessage payloads are appended to the
+    // deque by reference (zero-copy). Reads drain from the head chunk, tracked
+    // by headOffset; a chunk is removed from the deque once fully consumed.
+    //
+    // Invariants:
+    //   totalBuffered == sum of chunk.length for all chunk in chunks
+    //   0 <= headOffset < chunks.peekFirst().length   (when chunks non-empty)
+    //   headOffset == 0                                (when chunks empty)
+    //   bufferedBytes() == totalBuffered - headOffset
+    private final ArrayDeque<byte[]> chunks = new ArrayDeque<>();
+    private int totalBuffered;
+    private int headOffset;
+
     private boolean eof;
     private boolean overflowed;
 
     public RawChannelReader(int streamId, Channel channel) {
         this.streamId = streamId;
         this.channel = channel;
-        this.buffer = new byte[0];
         this.eof = false;
         this.listeners = new CopyOnWriteArrayList<>();
         try {
@@ -75,6 +81,11 @@ public class RawChannelReader extends InputStream {
         }
     }
 
+    /** Bytes still readable. Caller must hold {@code lock}. */
+    private int bufferedBytes() {
+        return totalBuffered - headOffset;
+    }
+
     private Boolean handleMessage(MessageBase message) {
         if (message instanceof StreamDataMessage) {
             StreamDataMessage streamMessage = (StreamDataMessage) message;
@@ -82,30 +93,30 @@ public class RawChannelReader extends InputStream {
                 lock.lock();
                 try {
                     byte[] data = streamMessage.getData();
-                    if (data != null && !overflowed) {
-                        // Guard against unbounded growth: if the next concat would push past
-                        // MAX_BUFFER_SIZE, drop the incoming chunk, mark EOF and stop accepting
-                        // further data on this stream. Use long arithmetic to avoid int overflow
-                        // when buffer.length + data.length > Integer.MAX_VALUE.
-                        long projected = (long) buffer.length + (long) data.length;
+                    if (data != null && data.length > 0 && !overflowed) {
+                        // Long arithmetic to avoid int overflow if MAX_BUFFER_SIZE is raised
+                        // via -Dio.reticulum.buffer.maxSize to something close to Integer.MAX_VALUE.
+                        long projected = (long) bufferedBytes() + (long) data.length;
                         if (projected > MAX_BUFFER_SIZE) {
                             overflowed = true;
                             eof = true;
                             log.warn("RawChannelReader buffer cap exceeded "
                                             + "(streamId={}, current={} bytes, incoming={} bytes, cap={} bytes) "
                                             + "— dropping data and signalling EOF to consumer",
-                                    streamId, buffer.length, data.length, MAX_BUFFER_SIZE);
+                                    streamId, bufferedBytes(), data.length, MAX_BUFFER_SIZE);
                         } else {
-                            buffer = concatArrays(buffer, data);
+                            // Zero-copy append: keep the reference, no reallocation.
+                            chunks.addLast(data);
+                            totalBuffered += data.length;
                         }
                     }
                     if (streamMessage.getEof()) {
                         eof = true;
                     }
 
+                    int readable = bufferedBytes();
                     for (Consumer<Integer> listener : listeners) {
-                        //new Thread(() -> listener.call(buffer.length)).start();
-                        new Thread(() -> listener.accept(buffer.length)).start();
+                        new Thread(() -> listener.accept(readable)).start();
                     }
                 } finally {
                     lock.unlock();
@@ -119,34 +130,61 @@ public class RawChannelReader extends InputStream {
     public int read() throws IOException {
         lock.lock();
         try {
-            if (buffer.length == 0 && eof) {
-                return -1;
+            if (bufferedBytes() == 0) {
+                return -1; // includes the EOF case
             }
-            if (buffer.length > 0) {
-                int result = buffer[0];
-                buffer = Arrays.copyOfRange(buffer, 1, buffer.length);
-                return result;
+            byte[] head = chunks.peekFirst();
+            int b = head[headOffset++] & 0xFF;
+            if (headOffset >= head.length) {
+                chunks.removeFirst();
+                totalBuffered -= head.length;
+                headOffset = 0;
             }
-            return -1;
+            return b;
         } finally {
             lock.unlock();
         }
     }
 
     /**
-     * @param readyBytes - The amount that is expected
-     * @return - A copy array.
-     * @throws IOException
-     * 
-     * Read a certain number of bytes from a callback alerting to
-     * a specific number of bytes being ready to be read.
+     * Read up to {@code readyBytes} bytes. Returned array is exactly the number
+     * of bytes actually drained (may be shorter than requested if the buffer
+     * holds fewer bytes — guards against the caller's ready-callback racing
+     * with consumer state).
+     *
+     * @param readyBytes the amount the caller expects to be ready
+     * @return a freshly allocated array containing the drained bytes
      */
     public byte[] read(Integer readyBytes) throws IOException {
         lock.lock();
         try {
-            var result = Arrays.copyOfRange(buffer, 0, readyBytes);
-            buffer = Arrays.copyOfRange(buffer, readyBytes, buffer.length);
+            int want = Math.min(readyBytes, bufferedBytes());
+            byte[] result = new byte[want];
+            int copied = 0;
+            while (copied < want) {
+                byte[] head = chunks.peekFirst();
+                int avail = head.length - headOffset;
+                int take = Math.min(avail, want - copied);
+                System.arraycopy(head, headOffset, result, copied, take);
+                copied += take;
+                headOffset += take;
+                if (headOffset >= head.length) {
+                    chunks.removeFirst();
+                    totalBuffered -= head.length;
+                    headOffset = 0;
+                }
+            }
             return result;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int available() {
+        lock.lock();
+        try {
+            return bufferedBytes();
         } finally {
             lock.unlock();
         }
@@ -156,8 +194,10 @@ public class RawChannelReader extends InputStream {
         log.debug("reater - flushing buffer");
         lock.lock();
         try {
-            this.buffer = new byte[0];
-            this.overflowed = false;
+            chunks.clear();
+            totalBuffered = 0;
+            headOffset = 0;
+            overflowed = false;
         } finally {
             lock.unlock();
         }
@@ -171,7 +211,7 @@ public class RawChannelReader extends InputStream {
         return false;
     }
 
-    public Boolean readable() { 
+    public Boolean readable() {
         return true;
     }
 
@@ -180,6 +220,9 @@ public class RawChannelReader extends InputStream {
         try {
             channel.removeMessageHandler(this::handleMessage);
             listeners.clear();
+            chunks.clear();
+            totalBuffered = 0;
+            headOffset = 0;
         } finally {
             lock.unlock();
         }

--- a/src/main/java/io/reticulum/buffer/RawChannelReader.java
+++ b/src/main/java/io/reticulum/buffer/RawChannelReader.java
@@ -21,6 +21,18 @@ import static io.reticulum.utils.IdentityUtils.concatArrays;
 
 @Slf4j
 public class RawChannelReader extends InputStream {
+    /**
+     * Hard cap on the inbound buffer per stream. When exceeded we drop further
+     * incoming data and mark the stream EOF so consumers stop. Without this cap
+     * a misbehaving (or simply faster-than-consumer) peer can drive
+     * {@code buffer = concatArrays(buffer, ...)} to OutOfMemoryError, which has
+     * been observed on public-facing nodes and propagates up into
+     * {@code Transport.inbound()}.
+     *
+     * Override via {@code -Dio.reticulum.buffer.maxSize=<bytes>}.
+     */
+    public static final int MAX_BUFFER_SIZE =
+            Integer.getInteger("io.reticulum.buffer.maxSize", 8 * 1024 * 1024); // 8 MiB
     private final int streamId;
     private final Channel channel;
     private final ReentrantLock lock = new ReentrantLock();
@@ -28,6 +40,7 @@ public class RawChannelReader extends InputStream {
     private StreamDataMessage sdm = new StreamDataMessage();
     private byte[] buffer;
     private boolean eof;
+    private boolean overflowed;
 
     public RawChannelReader(int streamId, Channel channel) {
         this.streamId = streamId;
@@ -68,13 +81,28 @@ public class RawChannelReader extends InputStream {
             if (streamMessage.getStreamId().equals(this.streamId)) {
                 lock.lock();
                 try {
-                    if (streamMessage.getData() != null) {
-                        buffer = concatArrays(buffer, streamMessage.getData());
+                    byte[] data = streamMessage.getData();
+                    if (data != null && !overflowed) {
+                        // Guard against unbounded growth: if the next concat would push past
+                        // MAX_BUFFER_SIZE, drop the incoming chunk, mark EOF and stop accepting
+                        // further data on this stream. Use long arithmetic to avoid int overflow
+                        // when buffer.length + data.length > Integer.MAX_VALUE.
+                        long projected = (long) buffer.length + (long) data.length;
+                        if (projected > MAX_BUFFER_SIZE) {
+                            overflowed = true;
+                            eof = true;
+                            log.warn("RawChannelReader buffer cap exceeded "
+                                            + "(streamId={}, current={} bytes, incoming={} bytes, cap={} bytes) "
+                                            + "— dropping data and signalling EOF to consumer",
+                                    streamId, buffer.length, data.length, MAX_BUFFER_SIZE);
+                        } else {
+                            buffer = concatArrays(buffer, data);
+                        }
                     }
                     if (streamMessage.getEof()) {
                         eof = true;
                     }
-                    
+
                     for (Consumer<Integer> listener : listeners) {
                         //new Thread(() -> listener.call(buffer.length)).start();
                         new Thread(() -> listener.accept(buffer.length)).start();
@@ -126,7 +154,13 @@ public class RawChannelReader extends InputStream {
 
     public void flush() {
         log.debug("reater - flushing buffer");
-        this.buffer = new byte[0];
+        lock.lock();
+        try {
+            this.buffer = new byte[0];
+            this.overflowed = false;
+        } finally {
+            lock.unlock();
+        }
     }
 
     public Boolean seekable() {

--- a/src/main/java/io/reticulum/buffer/RawChannelWriter.java
+++ b/src/main/java/io/reticulum/buffer/RawChannelWriter.java
@@ -15,6 +15,18 @@ public class RawChannelWriter extends OutputStream {
     private static final int MAX_CHUNK_LEN = 1024 * 16;
     private static final int COMPRESSION_TRIES = 4;
 
+    /**
+     * Block size passed to {@link BZip2CompressorOutputStream}. The value is
+     * multiplied by 100 KB internally, so block size 1 = 100 KB block and about
+     * 600 KB of transient allocation per compressor instance; block size 9
+     * (Apache Commons Compress default) = 900 KB block and about 5–6 MB per
+     * instance. Since MAX_CHUNK_LEN is only 16 KB, block size 1 gives us
+     * plenty of compression room while cutting the per-write transient heap
+     * cost by ~9×. Block size is stored in the bzip2 header, so decompressors
+     * auto-adapt — this does not affect wire compatibility.
+     */
+    private static final int BZIP2_BLOCK_SIZE = 1;
+
     private final int streamId;
     private final Channel channel;
     private boolean eof = false;
@@ -57,7 +69,7 @@ public class RawChannelWriter extends OutputStream {
             while (chunkLen > 32 && compTry < COMPRESSION_TRIES) {
                 int chunkSegmentLength = chunkLen / compTry;
                 ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                BZip2CompressorOutputStream bzip2OutputStream = new BZip2CompressorOutputStream(byteArrayOutputStream);
+                BZip2CompressorOutputStream bzip2OutputStream = new BZip2CompressorOutputStream(byteArrayOutputStream, BZIP2_BLOCK_SIZE);
                 bzip2OutputStream.write(chunk, 0, chunkSegmentLength);
                 bzip2OutputStream.close();
                 compressedChunk = byteArrayOutputStream.toByteArray();

--- a/src/main/java/io/reticulum/packet/PacketReceipt.java
+++ b/src/main/java/io/reticulum/packet/PacketReceipt.java
@@ -63,7 +63,16 @@ public class PacketReceipt {
 
     public synchronized boolean validateProofPacket(@NonNull final Packet proofPacket) {
         if (proofPacket.getDestinationType() == DestinationType.LINK) {
-            return validateLinkProof((Link) proofPacket.getDestination(), proofPacket);
+            // proofPacket.getDestination() can be null if the link was torn down
+            // between the receipt being enqueued (as deferred I/O in Transport.inbound)
+            // and the deferred runnable actually executing. In that case there is
+            // nothing to validate against — treat as a no-op rather than NPE.
+            var linkDest = proofPacket.getDestination();
+            if (linkDest == null) {
+                log.debug("validateProofPacket: link destination is null (link likely torn down); skipping proof validation");
+                return false;
+            }
+            return validateLinkProof((Link) linkDest, proofPacket);
         } else {
             return  validateProof(proofPacket.getData(), proofPacket);
         }
@@ -130,13 +139,18 @@ public class PacketReceipt {
     }
 
     /**
-     * Validate a raw proof for a link
+     * Validate a raw proof for a link. Returns false (rather than throwing) if
+     * the link reference is null, which can happen if the link was torn down
+     * after the receipt was enqueued for deferred validation.
      *
-     * @param link
-     * @param proofPacket
-     * @return
+     * @param link        the link to validate against; may be null
+     * @param proofPacket the proof packet
+     * @return true iff the proof validated and delivery callbacks fired
      */
-    private boolean validateLinkProof(@NonNull final Link link, @NonNull final Packet proofPacket) {
+    private boolean validateLinkProof(final Link link, @NonNull final Packet proofPacket) {
+        if (link == null) {
+            return false;
+        }
         var proof = proofPacket.getData();
         if (proof.length == EXPL_LENGTH) {
             //This is an explicit proof

--- a/src/main/java/io/reticulum/storage/Storage.java
+++ b/src/main/java/io/reticulum/storage/Storage.java
@@ -18,16 +18,19 @@ import io.reticulum.storage.entity.TunnelEntity;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.common.mapper.SimpleNitriteMapper;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.mvstore.MVStoreModule;
 
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -38,6 +41,7 @@ import static org.dizitart.no2.collection.FindOptions.orderBy;
 import static org.dizitart.no2.common.SortOrder.Descending;
 import static org.dizitart.no2.common.util.Iterables.setOf;
 
+@Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Storage {
 
@@ -55,6 +59,15 @@ public final class Storage {
 
 
     private final Nitrite db;
+
+    /**
+     * Latched once the packet cache is observed to be unavailable (e.g. the
+     * underlying Nitrite/MVStore was closed after a disk-full write failure).
+     * Used to log a single WARN instead of one per inbound packet — without
+     * this guard a stuck store has been observed to spam thousands of
+     * identical stack traces in {@code Transport.pathRequestHandler}.
+     */
+    private final AtomicBoolean packetCacheUnavailableLogged = new AtomicBoolean(false);
 
     public static Storage getInstance() {
         if (STORAGE == null) {
@@ -172,15 +185,40 @@ public final class Storage {
     }
 
     public void savePacketCache(@NonNull final PacketCache packetCache) {
-        doInTransactionWithoutResult(__ -> {
-            var repo = db.getRepository(PacketCache.class);
-            repo.update(packetCache, true);
-        });
+        try {
+            doInTransactionWithoutResult(__ -> {
+                var repo = db.getRepository(PacketCache.class);
+                repo.update(packetCache, true);
+            });
+        } catch (NitriteException e) {
+            // Packet cache is optional: if the underlying store is closed (e.g.
+            // disk-full write failure earlier), continue without caching rather
+            // than propagating to per-packet error sites.
+            logPacketCacheUnavailable(e);
+        }
     }
 
     public PacketCache getPacketCache(@NonNull final String packetHash) {
-        return db.getRepository(PacketCache.class)
-                .getById(packetHash);
+        try {
+            return db.getRepository(PacketCache.class)
+                    .getById(packetHash);
+        } catch (NitriteException e) {
+            // Treat a closed/unavailable store as a cache miss. Caller already
+            // handles null gracefully (Transport.getCachedPacket returns null →
+            // path request continues without cached reply).
+            logPacketCacheUnavailable(e);
+            return null;
+        }
+    }
+
+    private void logPacketCacheUnavailable(NitriteException e) {
+        if (packetCacheUnavailableLogged.compareAndSet(false, true)) {
+            log.warn("Packet cache unavailable ({}: {}). Continuing without cache; further "
+                            + "occurrences logged at DEBUG only.",
+                    e.getClass().getSimpleName(), e.getMessage());
+        } else {
+            log.debug("Packet cache still unavailable: {}", e.getMessage());
+        }
     }
 
     public void cleanPacketCache() {

--- a/src/main/java/io/reticulum/utils/Scheduler.java
+++ b/src/main/java/io/reticulum/utils/Scheduler.java
@@ -21,8 +21,19 @@ public class Scheduler {
                 () -> {
                     try {
                         command.run();
-                    } catch (Exception e) {
-                        log.error("Error while execute task", e);
+                    } catch (Throwable t) {
+                        // Catch Throwable, not just Exception: OutOfMemoryError and other
+                        // Errors otherwise escape this safety net and abort the scheduled
+                        // task (ScheduledExecutorService suppresses subsequent executions
+                        // on exceptional completion). Swallow so the next tick fires
+                        // normally — matches the "safe" intent of this wrapper.
+                        // The logger itself may allocate; wrap it so a logger-OOM does
+                        // not bypass the swallow.
+                        try {
+                            log.error("Error while execute task", t);
+                        } catch (Throwable ignored) {
+                            // Best-effort: if the logger itself fails, drop quietly.
+                        }
                     }
                 }, 100, delay, unite);
 


### PR DESCRIPTION
Description:
Changes to Buffer structure, cap buffer size, scheduler hardening, lock/unlock before logging.

Changes include:

* lock/unlock before logging: Avoid deadlocks under load by logging before locking and unlocking before logging.
* buffer growth cap: cap buffer size
* buffer structure: Use chunk queue instead of buffer []. Reduces buffer size by 2/3 and keeps it stable.
* fix PacketReceipt.validateLinkProof NPE.
* graceful degradation on Nitite close.