### PR TITLE
Fix Unbounded Nitrite Growth & more

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Welcome to:
 - [Reticulum](https://reticulum.network/) Manual (EN)
 - [LXMF](https://github.com/markqvist/LXMF) Specification (EN)
 - GitHub: [JReticulum](https://github.com/sergst83/reticulum-network-stack)
+- [LXMF (Java)](https://github.com/jschulthess/lightweight-extensible-message-format) (EN)
+- [LXST (Java)](https://github.com/jschulthess/lightweight-extensible-signal-transport) (EN)
 
 Создано с ❤️ для децентрализованной связи. \
 Built with ❤️ for decentralized communication.

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
             <dependency>
                 <groupId>org.dizitart</groupId>
                 <artifactId>nitrite-bom</artifactId>
-                <version>4.3.3</version>
+                <version>4.4.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
             <dependency>
                 <groupId>org.dizitart</groupId>
                 <artifactId>nitrite-bom</artifactId>
-                <version>4.4.1</version>
+                <version>4.3.3</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/io/reticulum/Reticulum.java
+++ b/src/main/java/io/reticulum/Reticulum.java
@@ -8,6 +8,7 @@ import io.reticulum.interfaces.local.LocalServerInterface;
 import io.reticulum.storage.Storage;
 import io.reticulum.utils.IdentityUtils;
 import io.reticulum.utils.InterfaceUtils;
+import io.reticulum.utils.Scheduler;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
@@ -139,6 +140,11 @@ public class Reticulum implements ExitHandler {
     public void exitHandler() {
         transport.exitHandler();
         IdentityUtils.exitHandler();
+        // Stop the shared scheduler last, after data has been persisted. This halts
+        // Transport.jobs() and the periodic announce/persist work so the mesh stops
+        // recovering once shutdown has begun (previously these kept running and the
+        // node appeared to "keep building the mesh" during shutdown).
+        Scheduler.shutdown();
     }
 
     public void persistData() {

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -302,8 +302,12 @@ public final class Transport implements ExitHandler {
                 });
 
         if (isFalse(owner.isConnectedToSharedInstance())) {
+            // The packet hashlist is an in-memory dedup window only (Python RNS
+            // behaviour) and is no longer persisted. Do not load it from storage —
+            // a multi-GB legacy collection would be read into memory here and risk
+            // OOM at startup. Drop any legacy on-disk collection instead.
             packetHashMap.clear();
-            packetHashMap.putAll(storage.loadAllPacketHash());
+            storage.clearPacketHashList();
             reloadBlacklist();
         }
 
@@ -494,17 +498,13 @@ public final class Transport implements ExitHandler {
     }
 
     private void savePacketHashlist() {
-        if (owner.isConnectedToSharedInstance()) {
-            return;
-        }
-
-        var saveStart = Instant.now();
-        if (isFalse(owner.isTransportEnabled())) {
-            packetHashMap.clear();
-        }
-        log.debug("Saving packet hashlist to storage...");
-        storage.saveAllPacketHash(packetHashMap);
-        log.debug("Saved packet hashlist in {} ms", Duration.between(saveStart, Instant.now()).toMillis());
+        // The packet hashlist is an in-memory dedup window only (matching Python RNS)
+        // and is intentionally NOT persisted. The previous implementation upserted the
+        // current hashes into Nitrite on every persist but never deleted aged-out ones,
+        // so the on-disk collection grew without bound (the union of every packet hash
+        // ever seen) and drove jreticulum.db into multi-GB territory on transport-enabled
+        // nodes. The in-memory map is bounded by the HASHLIST_MAXSIZE clear in jobs(), so
+        // nothing needs to be written here.
     }
 
     private void savePathTable() {
@@ -2955,9 +2955,11 @@ public final class Transport implements ExitHandler {
                 long _announcesMs = System.currentTimeMillis() - _t; _t = System.currentTimeMillis();
 
                 //Cull the packet hashlist if it has reached its max size
-                // storage.trimPacketHashList() reads 1M Nitrite DB records while holding jobsLock,
-                // which can take 60+ seconds and block all outbound/inbound traffic. Since packet-
-                // dedup works in a rolling window (not a full multi-day history), a simple in-memory
+                // The packet hashlist is an in-memory-only dedup window (never persisted).
+                // Persisting it previously drove jreticulum.db into multi-GB territory, and a
+                // DB-backed trim read 1M Nitrite records while holding jobsLock (60+ seconds,
+                // blocking all traffic). Since packet-dedup works in a rolling window (not a
+                // full multi-day history), a simple in-memory
                 // clear is sufficient and matches Python RNS behaviour (in-memory only).
                 if (packetHashMap.size() > HASHLIST_MAXSIZE) {
                     log.warn("packetHashMap reached {} entries — clearing in-memory dedup table", packetHashMap.size());

--- a/src/main/java/io/reticulum/Transport.java
+++ b/src/main/java/io/reticulum/Transport.java
@@ -106,6 +106,7 @@ import static io.reticulum.constant.TransportConstant.PATH_REQUEST_GRACE;
 import static io.reticulum.constant.TransportConstant.PATH_REQUEST_MI;
 import static io.reticulum.constant.TransportConstant.PATH_REQUEST_RG;
 import static io.reticulum.constant.TransportConstant.PATH_REQUEST_TIMEOUT;
+import static io.reticulum.constant.TransportConstant.RANDOM_BLOBS_MAX_PER_DESTINATION;
 import static io.reticulum.constant.TransportConstant.RECEIPTS_CHECK_INTERVAL;
 import static io.reticulum.constant.TransportConstant.REVERSE_TIMEOUT;
 import static io.reticulum.constant.TransportConstant.ROAMING_PATH_TIME;
@@ -1276,6 +1277,14 @@ public final class Transport implements ExitHandler {
                             }
 
                             randomBlobs.add(randomBlob);
+                            // Bound the list: drop oldest entries once we exceed the cap.
+                            // Without this the list grows monotonically (one blob per
+                            // unique announce) and is fully serialized on every 12h
+                            // savePathTable() dump, which on transport-enabled public
+                            // nodes has driven jreticulum.db into multi-GB territory.
+                            while (randomBlobs.size() > RANDOM_BLOBS_MAX_PER_DESTINATION) {
+                                randomBlobs.remove(0);
+                            }
 
                             if ((owner.isTransportEnabled() || fromLocalClient(packet)) && packet.getContext() != PATH_RESPONSE) {
                                 //Insert announce into announce table for retransmission

--- a/src/main/java/io/reticulum/channel/Channel.java
+++ b/src/main/java/io/reticulum/channel/Channel.java
@@ -367,12 +367,19 @@ public class Channel {
     }
 
     private void packetTimeout(Packet packet) {
+        // Deferred until AFTER packetTxOp releases Channel.lock. Calling
+        // outlet.timedOut() (→ Link.teardown, synchronized on Link) or
+        // shutdown() from inside the retry lambda would run them while
+        // Channel.lock is still held — and Link.receive → Channel.receive
+        // takes the two locks in the opposite order. That's an ABBA
+        // deadlock (observed: Synchronizer parked on Channel.lock while a
+        // worker was blocked on the Link monitor).
+        final boolean[] shouldTeardown = { false };
+
         Function<Envelope, Boolean> retryEnvelope = envelope -> {
             if (envelope.getTries() >= maxTries) {
                 log.error("Channel: Retry count exceeded, tearing down Link.");
-                shutdown();
-                outlet.timedOut();
-
+                shouldTeardown[0] = true;
                 return true;
             }
             envelope.setTries(envelope.getTries() + 1);
@@ -394,6 +401,12 @@ public class Channel {
 
         if (outlet.getPacketState(packet) != MSGSTATE_DELIVERED) {
             packetTxOp(packet, retryEnvelope);
+        }
+
+        // Runs OUTSIDE Channel.lock — safe to take Link monitor / Channel monitor here.
+        if (shouldTeardown[0]) {
+            shutdown();
+            outlet.timedOut();
         }
     }
 

--- a/src/main/java/io/reticulum/constant/TransportConstant.java
+++ b/src/main/java/io/reticulum/constant/TransportConstant.java
@@ -59,4 +59,16 @@ public class TransportConstant {
     public static final int MAX_PR_TAGS = 32_000;
     public static final long TABLES_CULL_INTERVAL = 5_000; //ms
 
+    /**
+     * Cap on the number of most-recent random blobs kept per destination in
+     * {@code Hops.randomBlobs}. Without a cap the list grows monotonically —
+     * one blob per unique announce heard — and is fully serialized on every
+     * 12-hour {@code savePathTable()} dump, which on public transport-enabled
+     * nodes has been observed to drive the Nitrite jreticulum.db file into
+     * multi-gigabyte territory. 128 keeps a replay-detection window that
+     * comfortably covers any realistic announce rate while bounding
+     * per-destination footprint to ~1 KB.
+     */
+    public static final int RANDOM_BLOBS_MAX_PER_DESTINATION = 128;
+
 }

--- a/src/main/java/io/reticulum/interfaces/AbstractConnectionInterface.java
+++ b/src/main/java/io/reticulum/interfaces/AbstractConnectionInterface.java
@@ -53,6 +53,23 @@ import static org.apache.commons.lang3.BooleanUtils.isFalse;
 @Slf4j
 public abstract class AbstractConnectionInterface extends Thread implements ConnectionInterface {
 
+    /**
+     * Shared, daemon-backed scheduler for pacing announce-queue processing across all
+     * interfaces. Previously {@link #processAnnounceQueue()} created a brand-new
+     * {@code newSingleThreadScheduledExecutor()} on every call with
+     * {@code scheduleAtFixedRate} — a non-daemon, never-shut-down executor that both
+     * kept firing forever and multiplied on each pass, leaking threads (observed as a
+     * large, growing set of {@code pool-*} threads) and preventing clean JVM exit on
+     * shutdown. A single shared daemon executor with a one-shot {@code schedule} is
+     * sufficient: the method re-schedules itself while the queue is non-empty.
+     */
+    private static final java.util.concurrent.ScheduledExecutorService ANNOUNCE_QUEUE_EXECUTOR =
+            Executors.newSingleThreadScheduledExecutor(runnable -> {
+                var thread = new Thread(runnable, "announce-queue");
+                thread.setDaemon(true);
+                return thread;
+            });
+
     @JsonProperty("outgoing")
     protected boolean OUT = true;
     protected boolean IN = false;
@@ -247,9 +264,11 @@ public abstract class AbstractConnectionInterface extends Thread implements Conn
                     announceQueue.remove(selected);
 
                     if (!announceQueue.isEmpty()) {
-                        Executors
-                                .newSingleThreadScheduledExecutor()
-                                .scheduleAtFixedRate(this::processAnnounceQueue, 1, waitTime, TimeUnit.SECONDS);
+                        // One-shot: process the next queued announce after waitTime. This method
+                        // re-schedules itself as long as entries remain, so a repeating
+                        // scheduleAtFixedRate (on a fresh, leaked executor) is neither needed nor
+                        // correct — it compounded into many orphaned non-daemon timers.
+                        ANNOUNCE_QUEUE_EXECUTOR.schedule(this::processAnnounceQueue, waitTime, TimeUnit.SECONDS);
                     }
                 }
             } catch (Exception e) {

--- a/src/main/java/io/reticulum/interfaces/auto/AutoInterface.java
+++ b/src/main/java/io/reticulum/interfaces/auto/AutoInterface.java
@@ -50,7 +50,6 @@ import static java.lang.Byte.toUnsignedInt;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.nonNull;
-import static java.util.concurrent.Executors.defaultThreadFactory;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
@@ -106,7 +105,15 @@ public class AutoInterface extends AbstractConnectionInterface implements AutoIn
 
     @Setter(PRIVATE)
     @Getter(PRIVATE)
-    private ThreadFactory defaultThreadFactory = defaultThreadFactory();
+    // Daemon threads: the discovery and listener threads below run blocking
+    // socket.receive() loops with no stop signal; as non-daemon threads they
+    // prevented the JVM from exiting on shutdown (the node "would not stop" and
+    // had to be killed). Daemon so process exit is never blocked by them.
+    private ThreadFactory defaultThreadFactory = runnable -> {
+        var thread = new Thread(runnable);
+        thread.setDaemon(true);
+        return thread;
+    };
 
     private ScheduledExecutorService scheduledThreadPool = newScheduledThreadPool(2, defaultThreadFactory);
 

--- a/src/main/java/io/reticulum/interfaces/auto/AutoInterfaceConstant.java
+++ b/src/main/java/io/reticulum/interfaces/auto/AutoInterfaceConstant.java
@@ -89,4 +89,22 @@ public final class AutoInterfaceConstant {
 
     static final Predicate<NetworkInterface> HAS_IPV6_ADDRESS = netIface -> netIface.inetAddresses()
             .anyMatch(inetAddress -> inetAddress instanceof Inet6Address);
+
+    /**
+     * Only keep interfaces that can actually carry multicast discovery traffic:
+     * up, multicast-capable and non-loopback. Without this, a device that still
+     * exposes a stale link-local IPv6 address but has no carrier/route (e.g. an
+     * unplugged USB-ethernet dongle) stays in the announce rotation and every
+     * peerAnnounce() send fails with "Network is unreachable" — observed spamming
+     * ERROR thousands of times over a run. isUp()/supportsMulticast() throw
+     * SocketException, so treat any failure as "not usable" and drop the interface.
+     */
+    static final Predicate<NetworkInterface> IS_USABLE = netIface -> {
+        try {
+            return netIface.isUp() && netIface.supportsMulticast() && isFalse(netIface.isLoopback());
+        } catch (java.net.SocketException e) {
+            log.debug("Skipping interface {} while checking usability: {}", netIface.getName(), e.getMessage());
+            return false;
+        }
+    };
 }

--- a/src/main/java/io/reticulum/interfaces/auto/AutoInterfaceUtil.java
+++ b/src/main/java/io/reticulum/interfaces/auto/AutoInterfaceUtil.java
@@ -14,6 +14,7 @@ import static io.reticulum.interfaces.auto.AutoInterfaceConstant.DARWIN_PREDICAT
 import static io.reticulum.interfaces.auto.AutoInterfaceConstant.HAS_IPV6_ADDRESS;
 import static io.reticulum.interfaces.auto.AutoInterfaceConstant.IGNORED_PREDICATE;
 import static io.reticulum.interfaces.auto.AutoInterfaceConstant.IN_ALL_IGNORE_IFS;
+import static io.reticulum.interfaces.auto.AutoInterfaceConstant.IS_USABLE;
 import static io.reticulum.interfaces.auto.AutoInterfaceConstant.NOT_IN_ALLOWED_PREDICATE;
 import static java.net.NetworkInterface.networkInterfaces;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -28,6 +29,7 @@ public interface AutoInterfaceUtil {
                 .filter(netIface -> IGNORED_PREDICATE.negate().test(netIface, instace))
                 .filter(netIface -> NOT_IN_ALLOWED_PREDICATE.negate().test(netIface, instace))
                 .filter(netIface -> IN_ALL_IGNORE_IFS.negate().test(netIface, instace))
+                .filter(IS_USABLE)
                 .filter(HAS_IPV6_ADDRESS)
                 .collect(toUnmodifiableList());
     }

--- a/src/main/java/io/reticulum/packet/PacketReceipt.java
+++ b/src/main/java/io/reticulum/packet/PacketReceipt.java
@@ -206,11 +206,24 @@ public class PacketReceipt {
         }
     }
 
-    public synchronized void setDeliveryCallback(Consumer<PacketReceipt> deliveryCallback) {
+    /**
+     * Register (or clear) the delivery callback.
+     *
+     * NOT synchronized on purpose: setting a callback is one reference write to
+     * a volatile field in {@link PacketReceiptCallbacks}. Taking the PacketReceipt
+     * monitor here creates a real ABBA deadlock — every caller inside {@code
+     * Channel} sets/clears callbacks while holding {@code Channel.lock}, while
+     * the delivery-dispatch path holds the PacketReceipt monitor (via
+     * {@code validateProof} being synchronized) and then acquires
+     * {@code Channel.lock} inside {@code Channel.packetDelivered}. Observed:
+     * Synchronizer thread parked on Channel.lock, no chain sync progress.
+     */
+    public void setDeliveryCallback(Consumer<PacketReceipt> deliveryCallback) {
         callbacks.setDelivery(deliveryCallback);
     }
 
-    public synchronized void setTimeoutCallback(Consumer<PacketReceipt> timeoutCallback) {
+    /** See {@link #setDeliveryCallback(Consumer)} for why this is not synchronized. */
+    public void setTimeoutCallback(Consumer<PacketReceipt> timeoutCallback) {
         callbacks.setTimeout(timeoutCallback);
     }
 }

--- a/src/main/java/io/reticulum/packet/PacketReceiptCallbacks.java
+++ b/src/main/java/io/reticulum/packet/PacketReceiptCallbacks.java
@@ -6,6 +6,11 @@ import java.util.function.Consumer;
 
 @Data
 public class PacketReceiptCallbacks {
-    private Consumer<PacketReceipt> delivery;
-    private Consumer<PacketReceipt> timeout;
+    // volatile: written by PacketReceipt.setDeliveryCallback / setTimeoutCallback
+    // (non-synchronized to avoid an ABBA with Channel.lock — see PacketReceipt),
+    // read by PacketReceipt's synchronized validate* methods when dispatching.
+    // Reference writes are atomic per JLS; volatile guarantees the reader sees
+    // the latest write without needing the PacketReceipt monitor for the write.
+    private volatile Consumer<PacketReceipt> delivery;
+    private volatile Consumer<PacketReceipt> timeout;
 }

--- a/src/main/java/io/reticulum/storage/Storage.java
+++ b/src/main/java/io/reticulum/storage/Storage.java
@@ -20,7 +20,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.MapUtils;
 import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.common.mapper.SimpleNitriteMapper;
 import org.dizitart.no2.exceptions.NitriteException;
@@ -34,11 +33,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static io.reticulum.constant.TransportConstant.HASHLIST_MAXSIZE;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static org.dizitart.no2.collection.FindOptions.orderBy;
-import static org.dizitart.no2.common.SortOrder.Descending;
 import static org.dizitart.no2.common.util.Iterables.setOf;
 
 @Slf4j
@@ -145,13 +141,16 @@ public final class Storage {
                 .collect(toMap(DestinationData::getDestinationHash, identity()));
     }
 
-    public void saveAllPacketHash(Map<String, byte[]> packetHashes) {
-        var repo = db.getRepository(PacketHash.class);
-        if (MapUtils.isNotEmpty(packetHashes)) {
-            doInTransactionWithoutResult(__ -> packetHashes.forEach((hex, bytes) -> repo.update(PacketHash.builder().packetHash(hex).hash(bytes).build(), true)));
-        } else {
-            repo.clear();
-        }
+    /**
+     * Clears the persisted packet hashlist collection. The packet hashlist is an
+     * in-memory dedup window only (matching Python RNS) and is no longer persisted:
+     * the previous {@code saveAllPacketHash()} upserted the current hashes but never
+     * deleted aged-out ones, so the on-disk collection grew without bound (the union
+     * of every packet hash ever seen) and drove jreticulum.db into multi-GB territory
+     * on transport-enabled nodes. This drops any (possibly legacy) on-disk collection.
+     */
+    public void clearPacketHashList() {
+        doInTransactionWithoutResult(__ -> db.getRepository(PacketHash.class).clear());
     }
 
     public void saveDestinationTables(Collection<DestinationTable> destinationTables) {
@@ -163,25 +162,6 @@ public final class Storage {
 
     public Collection<DestinationTable> getDestinationTables() {
         return db.getRepository(DestinationTable.class).find().toList();
-    }
-
-    public Map<String, byte[]> loadAllPacketHash() {
-        return db.getRepository(PacketHash.class).find()
-                .toList()
-                .stream()
-                .collect(toMap(PacketHash::getPacketHash, PacketHash::getHash));
-    }
-
-    public Map<String, byte[]> trimPacketHashList() {
-        var repo = db.getRepository(PacketHash.class);
-        var toSave = repo.find(orderBy("timestamp", Descending).limit(HASHLIST_MAXSIZE)).toList();
-        repo.clear();
-
-        return doInTransaction(() -> {
-            repo.insert(toSave.toArray(PacketHash[]::new));
-
-            return toSave.stream().collect(toMap(PacketHash::getPacketHash, PacketHash::getHash));
-        });
     }
 
     public void savePacketCache(@NonNull final PacketCache packetCache) {

--- a/src/main/java/io/reticulum/utils/Scheduler.java
+++ b/src/main/java/io/reticulum/utils/Scheduler.java
@@ -5,16 +5,36 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.util.concurrent.Executors.defaultThreadFactory;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 
 @UtilityClass
 @Slf4j
 public class Scheduler {
+
+    /**
+     * Daemon thread factory. The scheduler drives the core Transport.jobs() loop
+     * plus periodic persist/announce work; those must never keep the JVM alive
+     * once the host application is shutting down. Non-daemon scheduler threads were
+     * observed preventing clean process exit (the node "would not stop" and had to
+     * be killed) and kept the mesh recovering after shutdown had begun.
+     */
+    private static ThreadFactory daemonThreadFactory(String namePrefix) {
+        var counter = new AtomicInteger();
+        return runnable -> {
+            var thread = new Thread(runnable, namePrefix + "-" + counter.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+
     public static final ScheduledExecutorService scheduler =
-            newScheduledThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+            newScheduledThreadPool(Runtime.getRuntime().availableProcessors() * 2, daemonThreadFactory("rns-scheduler"));
+
+    private static final ThreadFactory watchdogThreadFactory = daemonThreadFactory("rns-scheduler-watchdog");
 
     public static void scheduleWithFixedDelaySafe(Runnable command, long delay, TimeUnit unite) {
         var future = scheduler.scheduleWithFixedDelay(
@@ -38,7 +58,7 @@ public class Scheduler {
                 }, 100, delay, unite);
 
         //watchdog
-        defaultThreadFactory().newThread(() -> {
+        var watchdog = watchdogThreadFactory.newThread(() -> {
             while (true) {
                 try {
                     future.get();
@@ -54,5 +74,16 @@ public class Scheduler {
                 }
             }
         });
+        watchdog.start();
+    }
+
+    /**
+     * Stops all scheduled work (Transport.jobs, periodic persist/announce, AutoInterface
+     * peerAnnounce/peerJob). Called from the Reticulum exit path so the mesh stops
+     * recovering once shutdown has begun and no scheduled task can keep the JVM alive.
+     * Safe to call more than once.
+     */
+    public static void shutdown() {
+        scheduler.shutdownNow();
     }
 }


### PR DESCRIPTION
Changes:

- Unbounded Nitrite DB growth showed up when exposed via BackboneServerInterface - fixed
- Bumped Nitrite to latest (4.4.2)
- Fixed potentially last thread deadlock issues
- Add references to Java implementations of LXMF and LXST
- Fix: build-up of threads preventing clean shutdown in exitHandler.
- Fix: AutoInteface throwing IPv6 errors on mal-functioning local network interface.